### PR TITLE
Fix Eclipse 4.2 error

### DIFF
--- a/butterknife/src/main/java/butterknife/Views.java
+++ b/butterknife/src/main/java/butterknife/Views.java
@@ -158,7 +158,8 @@ public class Views {
 
         String targetType = type.getQualifiedName().toString();
         String sourceType = resolveSourceType(type);
-        String packageName = processingEnv.getElementUtils().getPackageOf(type).toString();
+        String packageName =
+            processingEnv.getElementUtils().getPackageOf(type).getQualifiedName().toString();
         String className =
             type.getQualifiedName().toString().substring(packageName.length() + 1).replace('.', '$')
                 + SUFFIX;


### PR DESCRIPTION
When running the butterknife annotation processor in eclipse 4.2  I get the following error:

Unable to create package fragment for package package com.test.android.search.ui

It looks like getPackageOf(type) returns the whole package statement instead of just the package name.  Adding getQualifiedName() to the call chain should fix this.
