### PR TITLE
proguard configuration change

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -154,7 +154,7 @@ ImageView photo = Views.findById(view, R.id.photo);</pre>
             <h4 id="proguard">ProGuard</h4>
             <p>Butter Knife generates and uses classes dynamically which means that static analysis tools like ProGuard may think they are unused. In order to prevent them from being removed, explicitly mark them to be kept.</p>
             <pre>-dontwarn butterknife.Views$InjectViewProcessor
--keepclassmembers class **$$ViewInjector {*;}</pre>
+-keep class **$$ViewInjector { *; }</pre>
 
             <h3 id="license">License</h3>
             <pre class="license">Copyright 2013 Jake Wharton


### PR DESCRIPTION
The whole injector needs to be kept, as we experienced in another project: https://github.com/cgeo/cgeo/commit/b64fa6b76fa9bb84a185dabb95988f7ab0b7655b

With the old "keepclassmembers", we had NPEs when accessing viewholder instances. Those are gone with the config change.
