### PR TITLE
Proguard docs: Fix typo in keep option and add extra keepnames for annotated members

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,9 @@ ImageView photo = Views.findById(view, R.id.photo);</pre>
             <h4 id="proguard">ProGuard</h4>
             <p>Butter Knife generates and uses classes dynamically which means that static analysis tools like ProGuard may think they are unused. In order to prevent them from being removed, explicitly mark them to be kept.</p>
             <pre>-dontwarn butterknife.internal.**
---keep class **$$ViewInjector { *; }</pre>
+-keep class **$$ViewInjector { *; }</pre>
+            <p>To prevent ProGuard renaming classes that use @InjectView on a member field, add the following rule to your ProGuard configuration:</p>
+            <pre>-keepnames class * { @butterknife.InjectView *;}</pre>
 
             <h3 id="license">License</h3>
             <pre class="license">Copyright 2013 Jake Wharton


### PR DESCRIPTION
Add extra rule to prevent a class being renamed when any of it's members has an @InjectView annotation.
