### PR TITLE
Make injections required. Add @Optional annotation.

### DIFF
--- a/butterknife/src/it/optional/pom.xml
+++ b/butterknife/src/it/optional/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.butterknife.tests</groupId>
+  <artifactId>optional</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android</artifactId>
+      <version>4.1.1.4</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.jakewharton</groupId>
+      <artifactId>butterknife</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>robolectric</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>fest-android</artifactId>
+      <version>1.0.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/butterknife/src/it/optional/src/main/java/butterknife/FieldExample.java
+++ b/butterknife/src/it/optional/src/main/java/butterknife/FieldExample.java
@@ -1,0 +1,22 @@
+package butterknife;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+import butterknife.InjectView;
+import butterknife.Optional;
+import butterknife.Views;
+
+public class FieldExample extends Activity {
+  static boolean HAS_ONE = true;
+
+  @InjectView(1) View thing1;
+  @Optional @InjectView(2) View thing2;
+
+  @Override public View findViewById(int id) {
+    if (HAS_ONE && id == 1) {
+      return new View(this);
+    }
+    return null;
+  }
+}

--- a/butterknife/src/it/optional/src/main/java/butterknife/MethodExample.java
+++ b/butterknife/src/it/optional/src/main/java/butterknife/MethodExample.java
@@ -1,0 +1,26 @@
+package butterknife;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+import butterknife.InjectView;
+import butterknife.OnClick;
+import butterknife.Optional;
+import butterknife.Views;
+
+public class MethodExample extends Activity {
+  static boolean HAS_ONE = true;
+
+  @OnClick(1)
+  public void doStuff() {}
+
+  @Optional @OnClick(2)
+  public void doOtherStuff() {}
+
+  @Override public View findViewById(int id) {
+    if (HAS_ONE && id == 1) {
+      return new View(this);
+    }
+    return null;
+  }
+}

--- a/butterknife/src/it/optional/src/test/java/butterknife/FieldExampleTest.java
+++ b/butterknife/src/it/optional/src/test/java/butterknife/FieldExampleTest.java
@@ -1,0 +1,36 @@
+package butterknife;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class FieldExampleTest {
+  @Test public void missingOptionalViewIsValid() {
+    FieldExample.HAS_ONE = true;
+
+    FieldExample example = Robolectric.buildActivity(FieldExample.class).get();
+
+    Views.inject(example);
+    assertThat(example.thing1).isNotNull();
+    assertThat(example.thing2).isNull();
+  }
+
+  @Test public void missingRequiredViewThrowsException() {
+    FieldExample.HAS_ONE = false;
+
+    FieldExample example = Robolectric.buildActivity(FieldExample.class).get();
+
+    try {
+      Views.inject(example);
+    } catch (Views.UnableToInjectException e) {
+      assertThat(e.getCause().getCause()).hasMessage(
+          "Required view with id '1' for field 'thing1' was not found. If this field binding is optional add '@Optional'.");
+    }
+  }
+}

--- a/butterknife/src/it/optional/src/test/java/butterknife/MethodExampleTest.java
+++ b/butterknife/src/it/optional/src/test/java/butterknife/MethodExampleTest.java
@@ -1,0 +1,30 @@
+package butterknife;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class MethodExampleTest {
+  @Test public void missingOptionalViewIsValid() {
+    MethodExample.HAS_ONE = true;
+    MethodExample example = Robolectric.buildActivity(MethodExample.class).get();
+    Views.inject(example);
+  }
+
+  @Test public void missingRequiredViewThrowsException() {
+    MethodExample.HAS_ONE = false;
+    MethodExample example = Robolectric.buildActivity(MethodExample.class).get();
+    try {
+      Views.inject(example);
+    } catch (Views.UnableToInjectException e) {
+      assertThat(e.getCause().getCause()).hasMessage(
+          "Required view with id '1' for method 'doStuff' was not found. If this method binding is optional add '@Optional'.");
+    }
+  }
+}

--- a/butterknife/src/main/java/butterknife/Optional.java
+++ b/butterknife/src/main/java/butterknife/Optional.java
@@ -1,0 +1,12 @@
+package butterknife;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Retention(CLASS) @Target({ FIELD, METHOD })
+public @interface Optional {
+}

--- a/butterknife/src/main/java/butterknife/internal/InjectViewProcessor.java
+++ b/butterknife/src/main/java/butterknife/internal/InjectViewProcessor.java
@@ -2,6 +2,7 @@ package butterknife.internal;
 
 import butterknife.InjectView;
 import butterknife.OnClick;
+import butterknife.Optional;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
@@ -117,9 +118,10 @@ public class InjectViewProcessor extends AbstractProcessor {
       String name = element.getSimpleName().toString();
       int id = element.getAnnotation(InjectView.class).value();
       String type = element.asType().toString();
+      boolean required = element.getAnnotation(Optional.class) == null;
 
       TargetClass targetClass = getOrCreateTargetClass(targetClassMap, enclosingElement);
-      targetClass.addField(id, name, type);
+      targetClass.addField(id, name, type, required);
 
       // Add the type-erased version to the valid injection targets set.
       TypeMirror erasedTargetType = typeUtils.erasure(enclosingElement.asType());
@@ -187,6 +189,7 @@ public class InjectViewProcessor extends AbstractProcessor {
       // Assemble information on the injection point.
       String name = executableElement.getSimpleName().toString();
       int[] ids = element.getAnnotation(OnClick.class).value();
+      boolean required = element.getAnnotation(Optional.class) == null;
 
       TargetClass targetClass = getOrCreateTargetClass(targetClassMap, enclosingElement);
 
@@ -197,7 +200,7 @@ public class InjectViewProcessor extends AbstractProcessor {
           error(element, "@OnClick annotation for method %s contains duplicate ID %s.", element,
               id);
           bad = true;
-        } else if (!targetClass.addMethod(id, name, type)) {
+        } else if (!targetClass.addMethod(id, name, type, required)) {
           error(element, "Multiple @OnClick methods declared for ID %s in %s.", id,
               enclosingElement.getQualifiedName());
           bad = true;

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <plugin>
           <groupId>com.jayway.maven.plugins.android.generation2</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.6.0</version>
           <configuration>
             <sdk>
               <platform>${android.platform}</platform>


### PR DESCRIPTION
This changes all field and method injections to be required. An exception will be thrown if the ID cannot be found. Adding an `@Optional` annotation to fields or methods will omit this check.
