### PR TITLE
Do not emit cast if the type is View.

### DIFF
--- a/butterknife/src/main/java/butterknife/internal/InjectViewProcessor.java
+++ b/butterknife/src/main/java/butterknife/internal/InjectViewProcessor.java
@@ -39,6 +39,7 @@ import static javax.tools.Diagnostic.Kind.ERROR;
     "butterknife.OnClick" //
 })
 public class InjectViewProcessor extends AbstractProcessor {
+  static final String VIEW_TYPE = "android.view.View";
   public static final String SUFFIX = "$$ViewInjector";
 
   private Elements elementUtils;
@@ -243,7 +244,7 @@ public class InjectViewProcessor extends AbstractProcessor {
       return false;
     }
     DeclaredType declaredType = (DeclaredType) typeMirror;
-    if ("android.view.View".equals(declaredType.toString())) {
+    if (VIEW_TYPE.equals(declaredType.toString())) {
       return true;
     } else {
       Element element = declaredType.asElement();

--- a/butterknife/src/main/java/butterknife/internal/TargetClass.java
+++ b/butterknife/src/main/java/butterknife/internal/TargetClass.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static butterknife.internal.InjectViewProcessor.VIEW_TYPE;
+
 class TargetClass {
   private final Map<Integer, ViewId> viewIdMap = new LinkedHashMap<Integer, ViewId>();
   private final String classPackage;
@@ -80,9 +82,16 @@ class TargetClass {
         }
         builder.append("    target.")
             .append(fieldInjection.name)
-            .append(" = (")
+            .append(" = ");
+
+        // Only emit a cast if the type is not View.
+        if (!VIEW_TYPE.equals(fieldInjection.type)) {
+          builder.append("(")
             .append(fieldInjection.type)
-            .append(") view;\n");
+            .append(") ");
+        }
+
+        builder.append("view;\n");
       }
       MethodInjection method = viewId.method;
       if (method != null) {


### PR DESCRIPTION
This avoids compiler warnings for redundant casts.

I omitted tests for this because it would be challenging to make. Once #64 is in it would be much eaiser.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Butter Knife (Parent) ............................. SUCCESS [0.900s]
[INFO] Butter Knife ...................................... SUCCESS [1:47.455s]
[INFO] Butter Knife Sample ............................... SUCCESS [9.186s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1:58.318s
[INFO] Finished at: Sat Oct 05 19:55:03 PDT 2013
[INFO] Final Memory: 45M/475M
[INFO] ------------------------------------------------------------------------
```
