### PR TITLE
Fix issue #83: bad generated listener code when built with Eclipse

### DIFF
--- a/butterknife/src/main/java/butterknife/internal/Listener.java
+++ b/butterknife/src/main/java/butterknife/internal/Listener.java
@@ -74,11 +74,9 @@ final class Listener {
     this.parameterTypes = parameterTypes; // No defensive copy, only instantiated internally.
   }
 
-  // Fix issue #83 - when built with Eclipse, the generated listener code contains an errant
-  // type parameter
+  // When built with Eclipse, the generated listener code contains an errant type parameter.
   private static String stripTypeParameters(String type) {
-    int typeParamStart = type.indexOf("<");
-
+    int typeParamStart = type.indexOf('<');
     if (typeParamStart != -1) {
       return type.substring(0, typeParamStart);
     } else {


### PR DESCRIPTION
This works for me.

Caveats:
- Generates code with a warning.  This happens anyway when built with ant anyway though so this isn't making the situation worse
- There are no tests - it's quite a simple change but tests would be nice anyway. I didn't add any as the Listener test file is currently all disabled.
