### PR TITLE
ImmutableViewList should implement RandomAccess

### DIFF
--- a/butterknife/src/main/java/butterknife/ImmutableViewList.java
+++ b/butterknife/src/main/java/butterknife/ImmutableViewList.java
@@ -2,12 +2,13 @@ package butterknife;
 
 import android.view.View;
 import java.util.AbstractList;
+import java.util.RandomAccess;
 
 /**
  * An immutable list of views which is lighter than {@code
  * Collections.unmodifiableList(new ArrayList<>(Arrays.asList(foo, bar)))}.
  */
-final class ImmutableViewList<T extends View> extends AbstractList<T> {
+final class ImmutableViewList<T extends View> extends AbstractList<T> implements RandomAccess {
   private final T[] views;
 
   ImmutableViewList(T[] views) {


### PR DESCRIPTION
`get()` has constant-time performance, so the class should, I suppose, implement `RandomAccess` on the off chance that it ever makes a difference.
