### PR TITLE
Fix a ClassCastException when looking at the internals of an InvocationTargetException

### DIFF
--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -252,10 +252,11 @@ public final class ButterKnife {
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
-      if (e instanceof InvocationTargetException) {
-        e = (Exception) e.getCause();
+      Throwable t = e;
+      if (t instanceof InvocationTargetException) {
+        t = t.getCause();
       }
-      throw new RuntimeException("Unable to inject views for " + target, e);
+      throw new RuntimeException("Unable to inject views for " + target, t);
     }
   }
 


### PR DESCRIPTION
Managed to get a ClassCastException here in my CI environment, because an `java.lang.IllegalAccessError` was thrown during injection.
