### PR TITLE
Increase font size of code samples

### DIFF
--- a/website/static/app.css
+++ b/website/static/app.css
@@ -21,7 +21,6 @@ code, pre {
   border: none;
 }
 pre {
-  font-size: 10px;
   padding: 0;
   overflow: auto;
   word-wrap: normal;


### PR DESCRIPTION
I'm getting older (but I'm not that old!) and the doc website code snippets are painfully small and strain my eyes when reading them. This change bumps them back up to 13px.

:heart: 

Before:

![image](https://cloud.githubusercontent.com/assets/56947/3238100/cdf01280-f0f1-11e3-9c77-f85f35019b3b.png)

After:

![image](https://cloud.githubusercontent.com/assets/56947/3238105/d685aa68-f0f1-11e3-8c60-ae1e0086aa3c.png)
