### PR TITLE
Website: Add note about Java 1.6 requirement in Eclipse instructions

### DIFF
--- a/website/ide-eclipse.html
+++ b/website/ide-eclipse.html
@@ -37,6 +37,7 @@
               </li>
               <li>Click <em>"Ok"</em> to save the new settings. Eclipse will ask you to rebuild your project to which you should click <em>"Yes"</em></li>
               <li>Make sure that the <code>.apt_generated/</code> folder is in your project root. It should contain files like <code>YOURACTIVITY$$ViewInjector.java</code>. If these files are not present trigger a clean build by selected <em>Project &rarr; Clean</em>. This folder and files should not be checked into revision control.
+              <li>Lastly, under <em>"Java Compiler"</em>, make sure that the <em>Compiler compliance level</em> is set to Java version 1.6 at minimum.</li>
             </ol>
 
             <a id="ribbon" href="https://github.com/JakeWharton/butterknife"><img src="static/ribbon.png" alt="Fork me on GitHub"></a>


### PR DESCRIPTION
This took me a while to figure out. I followed the Eclipse instructions but the `.apt_generated` folder remained empty until I increased the Java compiler to 1.6.

See https://code.google.com/p/androidannotations/issues/detail?id=89
