### PR TITLE
Add version of `ButterKnife.findById()` for `Dialog` objects which infer...

### DIFF
--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -347,4 +347,10 @@ public final class ButterKnife {
   public static <T extends View> T findById(Activity activity, int id) {
     return (T) activity.findViewById(id);
   }
+
+  /** Simpler version of {@link Dialog#findViewById(int)} which infers the target type. */
+  @SuppressWarnings({ "unchecked", "UnusedDeclaration" }) // Checked by runtime cast. Public API.
+  public static <T extends View> T findById(Dialog dialog, int id) {
+    return (T) dialog.findViewById(id);
+  }
 }


### PR DESCRIPTION
...s the target type. Closes  #173.
