### PR TITLE
Added Codecov.io coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: android
+before_install: sudo pip install codecov
+after_success: codecov
 
 jdk:
  - oraclejdk7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Butter Knife
+Butter Knife [![codecov.io](https://codecov.io/github/JakeWharton/butterknife/coverage.svg?branch=master)](https://codecov.io/github/JakeWharton/butterknife?branch=master)
 ============
 
 ![Logo](website/static/logo.png)

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,25 @@
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.5.8.201207111220</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,25 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.5.8.201207111220</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -153,25 +172,6 @@
           <configuration>
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.5.8.201207111220</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>report</id>
-              <phase>test</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
I'm from [Codecov.io](https://codecov.io/) and I wanted to personally add our free coverage reporting tools to butterknife.

When travis-ci passes you can see the live reports here: [codecov.io/github/JakeWharton/butterknife](https://codecov.io/github/JakeWharton/butterknife?ref=10ec4d641ba308507154859785cdaa5a0ae27010)

Make sure to [signup](https://codecov.io/login/github) to enable these free [features](https://codecov.io/#features)

I'm excited to hear your feedback!
Thank you for your time.