### PR TITLE
Add some validation to elements before attempting to process them.

### DIFF
--- a/butterknife/pom.xml
+++ b/butterknife/pom.xml
@@ -14,6 +14,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.auto</groupId>
+      <artifactId>auto-common</artifactId>
+      <version>0.3</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/butterknife/src/main/java/butterknife/internal/ButterKnifeProcessor.java
+++ b/butterknife/src/main/java/butterknife/internal/ButterKnifeProcessor.java
@@ -607,7 +607,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
       erasedTargetNames.add(enclosingElement.toString());
     } else {
       // TODO (cgruber): Track skipped elements and re-try.
-      if (false) { this.hashCode(); }
+      if (false) { hashCode(); }
     }
   }
 


### PR DESCRIPTION
This change makes butterknife less prey to upstream compilation problems causing thrown exceptions rather than reported errors.