### PR TITLE
Disable injected TextWatchers during Click debounce period.

### DIFF
--- a/butterknife/src/main/java/butterknife/OnTextChanged.java
+++ b/butterknife/src/main/java/butterknife/OnTextChanged.java
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 @ListenerClass(
     targetType = "android.widget.TextView",
     setter = "addTextChangedListener",
-    type = "android.text.TextWatcher",
+    type = "butterknife.internal.DebouncingTextWatcher",
     callbacks = OnTextChanged.Callback.class
 )
 public @interface OnTextChanged {
@@ -50,7 +50,7 @@ public @interface OnTextChanged {
   enum Callback {
     /** {@link TextWatcher#onTextChanged(CharSequence, int, int, int)} */
     @ListenerMethod(
-        name = "onTextChanged",
+        name = "doTextChanged",
         parameters = {
             "java.lang.CharSequence",
             "int",
@@ -62,7 +62,7 @@ public @interface OnTextChanged {
 
     /** {@link TextWatcher#beforeTextChanged(CharSequence, int, int, int)} */
     @ListenerMethod(
-        name = "beforeTextChanged",
+        name = "doBeforeTextChanged",
         parameters = {
             "java.lang.CharSequence",
             "int",
@@ -74,7 +74,7 @@ public @interface OnTextChanged {
 
     /** {@link TextWatcher#afterTextChanged(android.text.Editable)} */
     @ListenerMethod(
-        name = "afterTextChanged",
+        name = "doAfterTextChanged",
         parameters = "android.text.Editable"
     )
     AFTER_TEXT_CHANGED,

--- a/butterknife/src/main/java/butterknife/internal/Debouncers.java
+++ b/butterknife/src/main/java/butterknife/internal/Debouncers.java
@@ -1,0 +1,17 @@
+package butterknife.internal;
+
+/**
+ * Static flag for debouncing input events, and a {@link Runnable} to re-enable them.
+ */
+class Debouncers {
+  static boolean enabled = true;
+
+  static final Runnable ENABLE_AGAIN = new Runnable() {
+    @Override public void run() {
+      enabled = true;
+    }
+  };
+
+  private Debouncers() {
+  }
+}

--- a/butterknife/src/main/java/butterknife/internal/DebouncingOnClickListener.java
+++ b/butterknife/src/main/java/butterknife/internal/DebouncingOnClickListener.java
@@ -2,18 +2,14 @@ package butterknife.internal;
 
 import android.view.View;
 
+import static butterknife.internal.Debouncers.ENABLE_AGAIN;
+import static butterknife.internal.Debouncers.enabled;
+
 /**
  * A {@linkplain View.OnClickListener click listener} that debounces multiple clicks posted in the
  * same frame. A click on one button disables all buttons for that frame.
  */
 public abstract class DebouncingOnClickListener implements View.OnClickListener {
-  private static boolean enabled = true;
-
-  private static final Runnable ENABLE_AGAIN = new Runnable() {
-    @Override public void run() {
-      enabled = true;
-    }
-  };
 
   @Override public final void onClick(View v) {
     if (enabled) {

--- a/butterknife/src/main/java/butterknife/internal/DebouncingTextWatcher.java
+++ b/butterknife/src/main/java/butterknife/internal/DebouncingTextWatcher.java
@@ -1,0 +1,39 @@
+package butterknife.internal;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+
+import static butterknife.internal.Debouncers.enabled;
+
+/**
+ * A {@linkplain TextWatcher text watcher} that debounces text events posted in the same frame
+ * as a button click.
+ */
+public class DebouncingTextWatcher implements TextWatcher {
+  @Override public final void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    if (enabled) {
+      doBeforeTextChanged(s, start, count, after);
+    }
+  }
+
+  @Override public final void onTextChanged(CharSequence s, int start, int before, int count) {
+    if (enabled) {
+      doTextChanged(s, start, before, count);
+    }
+  }
+
+  @Override public final void afterTextChanged(Editable s) {
+    if (enabled) {
+      doAfterTextChanged(s);
+    }
+  }
+
+  public void doBeforeTextChanged(CharSequence s, int start, int count, int after) {
+  }
+
+  public void doTextChanged(CharSequence s, int start, int before, int count) {
+  }
+
+  public void doAfterTextChanged(Editable s) {
+  }
+}

--- a/butterknife/src/test/java/butterknife/internal/OnTextChangedTest.java
+++ b/butterknife/src/test/java/butterknife/internal/OnTextChangedTest.java
@@ -29,13 +29,97 @@ public class OnTextChangedTest {
             "  public static void inject(Finder finder, final test.Test target, Object source) {",
             "    View view;",
             "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
-            "    ((android.widget.TextView) view).addTextChangedListener(new android.text.TextWatcher() {",
-            "      @Override public void onTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
+            "    ((android.widget.TextView) view).addTextChangedListener(new butterknife.internal.DebouncingTextWatcher() {",
+            "      @Override public void doTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
             "        target.doStuff();",
             "      }",
-            "      @Override public void beforeTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
+            "      @Override public void doBeforeTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
             "      }",
-            "      @Override public void afterTextChanged(android.text.Editable p0) {",
+            "      @Override public void doAfterTextChanged(android.text.Editable p0) {",
+            "      }",
+            "    });",
+            "  }",
+            "  public static void reset(test.Test target) {",
+            "  }",
+            "}"
+        ));
+
+    ASSERT.about(javaSource()).that(source)
+        .processedWith(butterknifeProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void beforeTextChanged() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
+        "package test;",
+        "import android.app.Activity;",
+        "import butterknife.OnTextChanged;",
+        "import static butterknife.OnTextChanged.Callback.BEFORE_TEXT_CHANGED;",
+        "public class Test extends Activity {",
+        "  @OnTextChanged(value = 1, callback = BEFORE_TEXT_CHANGED) void doStuff() {}",
+        "}"
+    ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewInjector",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.ButterKnife.Finder;",
+            "public class Test$$ViewInjector {",
+            "  public static void inject(Finder finder, final test.Test target, Object source) {",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    ((android.widget.TextView) view).addTextChangedListener(new butterknife.internal.DebouncingTextWatcher() {",
+            "      @Override public void doTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
+            "      }",
+            "      @Override public void doBeforeTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
+            "        target.doStuff();",
+            "      }",
+            "      @Override public void doAfterTextChanged(android.text.Editable p0) {",
+            "      }",
+            "    });",
+            "  }",
+            "  public static void reset(test.Test target) {",
+            "  }",
+            "}"
+        ));
+
+    ASSERT.about(javaSource()).that(source)
+        .processedWith(butterknifeProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void afterTextChanged() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
+        "package test;",
+        "import android.app.Activity;",
+        "import butterknife.OnTextChanged;",
+        "import static butterknife.OnTextChanged.Callback.AFTER_TEXT_CHANGED;",
+        "public class Test extends Activity {",
+        "  @OnTextChanged(value = 1, callback = AFTER_TEXT_CHANGED) void doStuff() {}",
+        "}"
+    ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewInjector",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.ButterKnife.Finder;",
+            "public class Test$$ViewInjector {",
+            "  public static void inject(Finder finder, final test.Test target, Object source) {",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    ((android.widget.TextView) view).addTextChangedListener(new butterknife.internal.DebouncingTextWatcher() {",
+            "      @Override public void doTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
+            "      }",
+            "      @Override public void doBeforeTextChanged(java.lang.CharSequence p0, int p1, int p2, int p3) {",
+            "      }",
+            "      @Override public void doAfterTextChanged(android.text.Editable p0) {",
+            "        target.doStuff();",
             "      }",
             "    });",
             "  }",


### PR DESCRIPTION
On some devices, typing into an EditText while holding a button down will fire the
button's click event before firing the text changed events. This works around that
by disabling text changed events during the button debounce period, making the
assumption that ignoring events in this case is better than seeing them out-of-order.