### PR TITLE
Fix broken proguard HTML

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -238,11 +238,11 @@ ImageView photo = ButterKnife.findById(view, R.id.photo);</pre>
 -keep class **$$ViewInjector { *; }
 
 -keepclasseswithmembernames class * {
-    @butterknife.* <fields>;
+    @butterknife.* &lt;fields&gt;;
 }
 
 -keepclasseswithmembernames class * {
-    @butterknife.* <methods>;
+    @butterknife.* &lt;methods&gt;;
 }</pre>
 
             <h3 id="license">License</h3>


### PR DESCRIPTION
Proguard configuration was broken because elements are being partly interpreted as HTML tags