### PR TITLE
Suppress unexpected exception in Previewer

### DIFF
--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -94,6 +94,15 @@ public final class ButterKnife {
       @Override public Context getContext(Object source) {
         return ((View) source).getContext();
       }
+
+      @Override protected String getResourceEntryName(Object source, int id) {
+        final View view = (View) source;
+        // In edit mode, getResourceEntryName() is unsupported due to use of BridgeResources
+        if (view.isInEditMode()) {
+          return "<unavailable while editing>";
+        }
+        return super.getResourceEntryName(source, id);
+      }
     },
     ACTIVITY {
       @Override protected View findView(Object source, int id) {
@@ -136,7 +145,7 @@ public final class ButterKnife {
     public <T> T findRequiredView(Object source, int id, String who) {
       T view = findOptionalView(source, id, who);
       if (view == null) {
-        String name = getContext(source).getResources().getResourceEntryName(id);
+        String name = getResourceEntryName(source, id);
         throw new IllegalStateException("Required view '"
             + name
             + "' with ID "
@@ -161,7 +170,7 @@ public final class ButterKnife {
         if (who == null) {
           throw new AssertionError();
         }
-        String name = view.getResources().getResourceEntryName(id);
+        String name = getResourceEntryName(view, id);
         throw new IllegalStateException("View '"
             + name
             + "' with ID "
@@ -187,6 +196,10 @@ public final class ButterKnife {
             + to
             + "'. See cause for more info.", e);
       }
+    }
+
+    protected String getResourceEntryName(Object source, int id) {
+      return getContext(source).getResources().getResourceEntryName(id);
     }
 
     protected abstract View findView(Object source, int id);

--- a/butterknife/src/test/java/butterknife/ButterKnifeTest.java
+++ b/butterknife/src/test/java/butterknife/ButterKnifeTest.java
@@ -5,6 +5,8 @@ import android.util.Property;
 import android.view.View;
 import java.util.Arrays;
 import java.util.List;
+
+import butterknife.shadow.EditModeShadowView;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +20,7 @@ import static butterknife.ButterKnife.Finder.listOf;
 import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.entry;
+import static org.fest.assertions.api.Assertions.fail;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -146,9 +149,23 @@ public class ButterKnifeTest {
     View view = new View(Robolectric.application);
     try {
       ButterKnife.Finder.VIEW.findRequiredView(view, android.R.id.button1, "yo mama");
+      fail("View 'button1' with ID " + android.R.id.button1 + " should not have been found.");
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Required view 'button1' with ID "
           + android.R.id.button1
+          + " for yo mama was not found. If this view is optional add '@Nullable' annotation.");
+    }
+  }
+
+  @Config(shadows = EditModeShadowView.class)
+  @Test public void finderThrowsLessNiceErrorInEditMode() {
+    View view = new View(Robolectric.application);
+    try {
+      ButterKnife.Finder.VIEW.findRequiredView(view, android.R.id.button1, "yo mama");
+      fail("View 'button1' with ID " + android.R.id.button1 + " should not have been found.");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Required view '<unavailable while editing>' "
+          + "with ID " + android.R.id.button1
           + " for yo mama was not found. If this view is optional add '@Nullable' annotation.");
     }
   }

--- a/butterknife/src/test/java/butterknife/shadow/EditModeShadowView.java
+++ b/butterknife/src/test/java/butterknife/shadow/EditModeShadowView.java
@@ -1,0 +1,18 @@
+package butterknife.shadow;
+
+import android.view.View;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowView;
+
+/**
+ * Behaves just like standard Robolectric views, but always reports that it is in Edit Mode.
+ */
+@Implements(View.class)
+public class EditModeShadowView extends ShadowView {
+  @SuppressWarnings("UnusedDeclaration")
+  @Implementation
+  public boolean isInEditMode() {
+    return true;
+  }
+}


### PR DESCRIPTION
Required views that were not found were calling a method that throws an
UnsupportedOperationException when in the Android Studio Previewer
(due to Previewer's use of BridgeResources). A check is now performed
to ensure that the view is not in Edit Mode before calling this method.