### PR TITLE
Clear Bitmap references on unbind().

### DIFF
--- a/butterknife/src/main/java/butterknife/internal/BindingClass.java
+++ b/butterknife/src/main/java/butterknife/internal/BindingClass.java
@@ -431,6 +431,9 @@ final class BindingClass {
     for (FieldCollectionViewBinding fieldCollectionBinding : collectionBindings.keySet()) {
       builder.append("    target.").append(fieldCollectionBinding.getName()).append(" = null;\n");
     }
+    for (FieldBitmapBinding fieldBitmapBinding : bitmapBindings) {
+      builder.append("    target.").append(fieldBitmapBinding.getName()).append(" = null;\n");
+    }
     builder.append("  }\n");
   }
 

--- a/butterknife/src/test/java/butterknife/internal/BindBitmapTest.java
+++ b/butterknife/src/test/java/butterknife/internal/BindBitmapTest.java
@@ -33,6 +33,7 @@ public class BindBitmapTest {
             "    target.one = BitmapFactory.decodeResource(res, 1);",
             "  }",
             "  @Override public void unbind(T target) {",
+            "    target.one = null;",
             "  }",
             "}"
         ));


### PR DESCRIPTION
#315, #316 

Not sure whether or not this is desirable, so feel free to reject.