### PR TITLE
Move unbind method to Unbinder interface.

### DIFF
--- a/butterknife-annotations/src/main/java/butterknife/Unbinder.java
+++ b/butterknife-annotations/src/main/java/butterknife/Unbinder.java
@@ -1,0 +1,19 @@
+package butterknife;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Bind a target field to an un-binder instance. Use when binding in a {@linkplain
+ * android.app.Fragment fragment}.
+ * <pre><code>
+ * {@literal @}Unbinder ButterKnife.Unbinder unbinder;
+ * </code></pre>
+ */
+@Retention(CLASS)
+@Target(FIELD)
+public @interface Unbinder {
+}

--- a/butterknife-compiler/src/main/java/butterknife/compiler/UnbinderBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/UnbinderBinding.java
@@ -1,0 +1,23 @@
+package butterknife.compiler;
+
+import com.squareup.javapoet.ClassName;
+
+class UnbinderBinding {
+  private static final String UNBINDER_SIMPLE_NAME = "Unbinder";
+
+  private final String unbinderFieldName;
+  private final ClassName unbinderClassName;
+
+  public UnbinderBinding(String packageName, String enclosingClassName, String fieldName) {
+    unbinderClassName = ClassName.get(packageName, enclosingClassName, UNBINDER_SIMPLE_NAME);
+    unbinderFieldName = fieldName;
+  }
+
+  public String getUnbinderFieldName() {
+    return unbinderFieldName;
+  }
+
+  public ClassName getUnbinderClassName() {
+    return unbinderClassName;
+  }
+}

--- a/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
@@ -33,8 +33,6 @@ public class BindArrayTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getStringArray(1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -67,8 +65,6 @@ public class BindArrayTest {
             "  @Override public void bind(final Finder finder, final T target, Object source) {",
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getIntArray(1);",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));
@@ -103,8 +99,6 @@ public class BindArrayTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getTextArray(1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -138,8 +132,6 @@ public class BindArrayTest {
             "  @Override public void bind(final Finder finder, final T target, Object source) {",
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.obtainTypedArray(1);",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/BindBitmapTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindBitmapTest.java
@@ -35,8 +35,6 @@ public class BindBitmapTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = BitmapFactory.decodeResource(res, 1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/BindBoolTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindBoolTest.java
@@ -33,8 +33,6 @@ public class BindBoolTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getBoolean(1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/BindColorTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindColorTest.java
@@ -37,8 +37,6 @@ public class BindColorTest {
             "    Resources.Theme theme = context.getTheme();",
             "    target.one = Utils.getColor(res, theme, 1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -76,8 +74,6 @@ public class BindColorTest {
             "    Resources res = context.getResources();",
             "    Resources.Theme theme = context.getTheme();",
             "    target.one = Utils.getColorStateList(res, theme, 1);",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/BindDimenTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindDimenTest.java
@@ -33,8 +33,6 @@ public class BindDimenTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getDimension(1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -67,8 +65,6 @@ public class BindDimenTest {
             "  @Override public void bind(final Finder finder, final T target, Object source) {",
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getDimensionPixelSize(1);",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/BindDrawableTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindDrawableTest.java
@@ -38,8 +38,6 @@ public class BindDrawableTest {
             "    Resources.Theme theme = context.getTheme();",
             "    target.one = Utils.getDrawable(res, theme, 1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -78,8 +76,6 @@ public class BindDrawableTest {
             "    Resources.Theme theme = context.getTheme();",
             "    target.one = Utils.getTintedDrawable(res, theme, 1, 2);",
             "",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/BindIntTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindIntTest.java
@@ -33,8 +33,6 @@ public class BindIntTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getInteger(1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/BindStringTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindStringTest.java
@@ -33,8 +33,6 @@ public class BindStringTest {
             "    Resources res = finder.getContext(source).getResources();",
             "    target.one = res.getString(1);",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/BindTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindTest.java
@@ -11,15 +11,16 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindTest {
   @Test public void bindingView() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import butterknife.Bind;",
-        "public class Test extends Activity {",
-        "    @Bind(1) View thing;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.app.Activity;",
+            "import android.view.View;",
+            "import butterknife.Bind;",
+            "public class Test extends Activity {",
+            "    @Bind(1) View thing;",
+            "}"
+        ));
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
         Joiner.on('\n').join(
@@ -34,9 +35,6 @@ public class BindTest {
             "    View view;",
             "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
             "    target.thing = view;",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -91,9 +89,6 @@ public class BindTest {
             "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
             "    target.thing = finder.castView(view, 1, \"field 'thing'\");",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
-            "  }",
             "}"
         ));
 
@@ -129,9 +124,6 @@ public class BindTest {
             "    View view;",
             "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
             "    target.thing = finder.castView(view, 1, \"field 'thing'\");",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -175,9 +167,6 @@ public class BindTest {
             "        target.doStuff();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing1 = null;",
             "  }",
             "}"
         ));
@@ -233,9 +222,6 @@ public class BindTest {
             "    view = finder.findOptionalView(source, 1, null);",
             "    target.view = view;",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.view = null;",
-            "  }",
             "}"
         ));
 
@@ -276,9 +262,6 @@ public class BindTest {
             "    view = finder.findRequiredView(source, 1, \"field 'view'\");",
             "    target.view = view;",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.view = null;",
-            "  }",
             "}"
         ));
 
@@ -296,10 +279,6 @@ public class BindTest {
             "    View view;",
             "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
             "    target.thing = view;",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    super.unbind(target);",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -341,9 +320,6 @@ public class BindTest {
             "    view = finder.findRequiredView(source, 1, \"field 'view'\");",
             "    target.view = view;",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.view = null;",
-            "  }",
             "}"
         ));
 
@@ -361,10 +337,6 @@ public class BindTest {
             "    View view;",
             "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
             "    target.thing = view;",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    super.unbind(target);",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -602,9 +574,6 @@ public class BindTest {
             "        finder.<View>findRequiredView(source, 3, \"field 'thing'\")",
             "    );",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
-            "  }",
             "}"
         ));
 
@@ -643,9 +612,6 @@ public class BindTest {
             "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"),",
             "        finder.<View>findRequiredView(source, 3, \"field 'thing'\")",
             "    );",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -687,9 +653,6 @@ public class BindTest {
             "        finder.<TextView>findRequiredView(source, 3, \"field 'thing'\")",
             "    );",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
-            "  }",
             "}"
         ));
 
@@ -729,9 +692,6 @@ public class BindTest {
             "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"),",
             "        finder.<View>findRequiredView(source, 3, \"field 'thing'\")",
             "    );",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -773,9 +733,6 @@ public class BindTest {
             "        finder.<Test.TestInterface>findRequiredView(source, 3, \"field 'thing'\")",
             "    );",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
-            "  }",
             "}"
         ));
 
@@ -815,9 +772,6 @@ public class BindTest {
             "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"),",
             "        finder.<View>findRequiredView(source, 3, \"field 'thing'\")",
             "    );",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
             "  }",
             "}"
         ));
@@ -859,9 +813,6 @@ public class BindTest {
             "        finder.<View>findOptionalView(source, 2, \"field 'thing'\"),",
             "        finder.<View>findOptionalView(source, 3, \"field 'thing'\")",
             "    );",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.thing = null;",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/ButterKnife.java
+++ b/butterknife-compiler/src/test/java/butterknife/ButterKnife.java
@@ -1,0 +1,8 @@
+package butterknife;
+
+/** STUB! Required for test sources to compile. */
+public class ButterKnife {
+  public interface Unbinder {
+    void unbind();
+  }
+}

--- a/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
@@ -39,8 +39,6 @@ public class OnCheckedChangedTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
@@ -38,8 +38,6 @@ public class OnClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -89,7 +87,6 @@ public class OnClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
             "}"));
 
     assertAbout(javaSource()).that(source)
@@ -130,9 +127,6 @@ public class OnClickTest {
             "        target.doStuff();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.view = null;",
             "  }",
             "}"
         ));
@@ -225,8 +219,6 @@ public class OnClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -279,8 +271,6 @@ public class OnClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -321,8 +311,6 @@ public class OnClickTest {
             "        }",
             "      });",
             "    }",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));
@@ -366,9 +354,6 @@ public class OnClickTest {
             "        target.doStuff();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
-            "    target.view = null;",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
@@ -40,8 +40,6 @@ public class OnEditorActionTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
@@ -38,8 +38,6 @@ public class OnFocusChangeTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
@@ -39,8 +39,6 @@ public class OnItemClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -86,8 +84,6 @@ public class OnItemClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -131,8 +127,6 @@ public class OnItemClickTest {
             "        target.doStuff(finder.<ListView>castParam(p0, \"onItemClick\", 0, \"doStuff\", 0), p2);",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));
@@ -178,8 +172,6 @@ public class OnItemClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -221,8 +213,6 @@ public class OnItemClickTest {
             "        target.doStuff();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
@@ -39,8 +39,6 @@ public class OnItemLongClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
@@ -42,8 +42,6 @@ public class OnItemSelectedTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 
@@ -86,8 +84,6 @@ public class OnItemSelectedTest {
             "        target.doStuff();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));
@@ -134,8 +130,6 @@ public class OnItemSelectedTest {
             "        target.onNothingSelected();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));
@@ -198,8 +192,6 @@ public class OnItemSelectedTest {
             "        target.onNothingSelected();",
             "      }",
             "    });",
-            "  }",
-            "  @Override public void unbind(T target) {",
             "  }",
             "}"
         ));

--- a/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
@@ -40,8 +40,6 @@ public class OnLongClickTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
@@ -43,8 +43,6 @@ public class OnPageChangeTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
@@ -46,8 +46,6 @@ public class OnTextChangedTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
@@ -39,8 +39,6 @@ public class OnTouchTest {
             "      }",
             "    });",
             "  }",
-            "  @Override public void unbind(T target) {",
-            "  }",
             "}"
         ));
 

--- a/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
@@ -1,0 +1,257 @@
+package butterknife;
+
+import butterknife.compiler.ButterKnifeProcessor;
+import com.google.common.base.Joiner;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class UnbinderTest {
+  @Test public void bindingUnbinder() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
+        .join(
+            "package test;",
+            "import android.app.Fragment;",
+            "import butterknife.ButterKnife;",
+            "import butterknife.OnClick;",
+            "import butterknife.Unbinder;",
+            "public class Test extends Fragment {",
+            "  @Unbinder ButterKnife.Unbinder unbinder;",
+            "  @OnClick(1) void doStuff() {",
+            "  }",
+            "}"
+        ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override public void bind(final Finder finder, final T target, Object source) {",
+            "    Unbinder unbinder = new Unbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    target.unbinder = unbinder;",
+            "  }",
+            "  private static final class Unbinder implements butterknife.ButterKnife.Unbinder {",
+            "    private Test target;",
+            "    View view1;",
+            "    Unbinder(Test target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override public void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      view1.setOnClickListener(null);",
+            "      target.unbinder = null;",
+            "      target = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void failWhenMultipleUnbinders() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
+        .join(
+            "package test;",
+            "import android.app.Fragment;",
+            "import butterknife.ButterKnife;",
+            "import butterknife.Unbinder;",
+            "public class Test extends Fragment {",
+            "  @Unbinder ButterKnife.Unbinder unbinder1;",
+            "  @Unbinder ButterKnife.Unbinder unbinder2;",
+            "}"
+        ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "Only one filed should be annotated with @Unbinder. (test.Test.unbinder2)")
+        .in(source).onLine(7);
+  }
+
+  @Test public void failOnWrongUnbinderType() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
+        .join(
+            "package test;",
+            "import android.app.Fragment;",
+            "import butterknife.Unbinder;",
+            "public class Test extends Fragment {",
+            "  @Unbinder Object unbinder;",
+            "}"
+        ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "@Unbinder filed must be of type ButterKnife.Unbinder. (test.Test.unbinder)")
+        .in(source).onLine(5);
+  }
+
+  @Test public void multipleBindings() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
+        .join(
+            "package test;",
+            "import android.app.Fragment;",
+            "import android.view.View;",
+            "import butterknife.Bind;",
+            "import butterknife.ButterKnife;",
+            "import butterknife.OnClick;",
+            "import butterknife.OnLongClick;",
+            "import butterknife.Unbinder;",
+            "public class Test extends Fragment {",
+            "  @Unbinder ButterKnife.Unbinder unbinder;",
+            "  @Bind(1) View view;",
+            "  @Bind(2) View view2;",
+            "  @OnClick(1) void doStuff() {",
+            "  }",
+            "  @OnLongClick(1) boolean doMoreStuff() { return false; }",
+            "}"
+        ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override public void bind(final Finder finder, final T target, Object source) {",
+            "    Unbinder unbinder = new Unbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'view', method 'doStuff', and method 'doMoreStuff'\");",
+            "    target.view = view;",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    view.setOnLongClickListener(new View.OnLongClickListener() {",
+            "      @Override public boolean onLongClick(View p0) {",
+            "        return target.doMoreStuff();",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 2, \"field 'view2'\");",
+            "    target.view2 = view;",
+            "    target.unbinder = unbinder;",
+            "  }",
+            "  private static final class Unbinder implements butterknife.ButterKnife.Unbinder {",
+            "    private Test target;",
+            "    View view1;",
+            "    Unbinder(Test target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override public void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      view1.setOnClickListener(null);",
+            "      view1.setOnLongClickListener(null);",
+            "      target.view = null;",
+            "      target.view2 = null;",
+            "      target.unbinder = null;",
+            "      target = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void unbinderRespectsNullable() {
+      JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
+          .join(
+              "package test;",
+              "import android.app.Fragment;",
+              "import butterknife.ButterKnife;",
+              "import butterknife.OnClick;",
+              "import butterknife.Unbinder;",
+              "public class Test extends Fragment {",
+              "  @interface Nullable {}",
+              "  @Unbinder ButterKnife.Unbinder unbinder;",
+              "  @Nullable @OnClick(1) void doStuff() {",
+              "  }",
+              "}"
+          ));
+
+      JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+          Joiner.on('\n').join(
+              "package test;",
+              "import android.view.View;",
+              "import butterknife.internal.DebouncingOnClickListener;",
+              "import butterknife.internal.Finder;",
+              "import butterknife.internal.ViewBinder;",
+              "import java.lang.IllegalStateException;",
+              "import java.lang.Object;",
+              "import java.lang.Override;",
+              "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+              "  @Override public void bind(final Finder finder, final T target, Object source) {",
+              "    Unbinder unbinder = new Unbinder(target);",
+              "    View view;",
+              "    view = finder.findOptionalView(source, 1, null);",
+              "    if (view != null) {",
+              "      unbinder.view1 = view;",
+              "      view.setOnClickListener(new DebouncingOnClickListener() {",
+              "        @Override public void doClick(View p0) {",
+              "          target.doStuff();",
+              "        }",
+              "      });",
+              "    }",
+              "    target.unbinder = unbinder;",
+              "  }",
+              "  private static final class Unbinder implements butterknife.ButterKnife.Unbinder {",
+              "    private Test target;",
+              "    View view1;",
+              "    Unbinder(Test target) {",
+              "      this.target = target;",
+              "    }",
+              "    @Override public void unbind() {",
+              "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+              "      if (view1 != null) {",
+              "        view1.setOnClickListener(null);",
+              "      }",
+              "      target.unbinder = null;",
+              "      target = null;",
+              "    }",
+              "  }",
+              "}"
+          ));
+
+      assertAbout(javaSource()).that(source)
+          .processedWith(new ButterKnifeProcessor())
+          .compilesWithoutError()
+          .and()
+          .generatesSources(expectedSource);
+  }
+}

--- a/butterknife-compiler/src/test/java/butterknife/internal/ViewBinder.java
+++ b/butterknife-compiler/src/test/java/butterknife/internal/ViewBinder.java
@@ -2,6 +2,4 @@ package butterknife.internal;
 
 public interface ViewBinder<T> {
   void bind(Finder finder, T target, Object source);
-
-  void unbind(T target);
 }

--- a/butterknife-sample/src/main/java/com/example/butterknife/SimpleActivity.java
+++ b/butterknife-sample/src/main/java/com/example/butterknife/SimpleActivity.java
@@ -9,6 +9,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import butterknife.Unbinder;
 import java.util.List;
 
 import butterknife.Bind;
@@ -35,6 +36,7 @@ public class SimpleActivity extends Activity {
   @Bind(R.id.hello) Button hello;
   @Bind(R.id.list_of_things) ListView listOfThings;
   @Bind(R.id.footer) TextView footer;
+  @Unbinder ButterKnife.Unbinder unbinder;
 
   @Bind({ R.id.title, R.id.subtitle, R.id.hello })
   List<View> headerViews;

--- a/butterknife-sample/src/test/java/com/example/butterknife/SimpleActivityTest.java
+++ b/butterknife-sample/src/test/java/com/example/butterknife/SimpleActivityTest.java
@@ -1,6 +1,5 @@
 package com.example.butterknife;
 
-import butterknife.ButterKnife;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -23,11 +22,12 @@ public class SimpleActivityTest {
     assertThat(activity.listOfThings.getId()).isEqualTo(R.id.list_of_things);
     assertThat(activity.footer.getId()).isEqualTo(R.id.footer);
 
-    ButterKnife.unbind(activity);
+    activity.unbinder.unbind();
     assertThat(activity.title).isNull();
     assertThat(activity.subtitle).isNull();
     assertThat(activity.hello).isNull();
     assertThat(activity.listOfThings).isNull();
     assertThat(activity.footer).isNull();
+    assertThat(activity.unbinder).isNull();
   }
 }

--- a/butterknife-sample/src/test/java/com/example/butterknife/SimpleAdapterTest.java
+++ b/butterknife-sample/src/test/java/com/example/butterknife/SimpleAdapterTest.java
@@ -3,7 +3,6 @@ package com.example.butterknife;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
-import butterknife.ButterKnife;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -25,10 +24,5 @@ public class SimpleAdapterTest {
     assertThat(holder.word.getId()).isEqualTo(R.id.word);
     assertThat(holder.length.getId()).isEqualTo(R.id.length);
     assertThat(holder.position.getId()).isEqualTo(R.id.position);
-
-    ButterKnife.unbind(holder);
-    assertThat(holder.word).isNull();
-    assertThat(holder.length).isNull();
-    assertThat(holder.position).isNull();
   }
 }

--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -80,6 +80,12 @@ public final class ButterKnife {
     throw new AssertionError("No instances.");
   }
 
+  /** An unbinder contract that can be bind with {@link butterknife.Unbinder}. */
+  @SuppressWarnings("unused") // Used by generated code.
+  public interface Unbinder {
+    void unbind();
+  }
+
   /** An action that can be applied to a list of views. */
   public interface Action<T extends View> {
     /** Apply the action on the {@code view} which is at {@code index} in the list. */
@@ -98,7 +104,6 @@ public final class ButterKnife {
   static final Map<Class<?>, ViewBinder<Object>> BINDERS = new LinkedHashMap<>();
   static final ViewBinder<Object> NOP_VIEW_BINDER = new ViewBinder<Object>() {
     @Override public void bind(Finder finder, Object target, Object source) { }
-    @Override public void unbind(Object target) { }
   };
 
   /** Control whether debug logging is enabled. */
@@ -133,6 +138,7 @@ public final class ButterKnife {
    *
    * @param target Target dialog for view binding.
    */
+  @SuppressWarnings("unused") // Public api.
   public static void bind(Dialog target) {
     bind(target, target, Finder.DIALOG);
   }
@@ -167,28 +173,9 @@ public final class ButterKnife {
    * @param target Target class for view binding.
    * @param source Dialog on which IDs will be looked up.
    */
+  @SuppressWarnings("unused") // Public api.
   public static void bind(Object target, Dialog source) {
     bind(target, source, Finder.DIALOG);
-  }
-
-  /**
-   * Reset fields annotated with {@link Bind @Bind} to {@code null}.
-   * <p>
-   * This should only be used in the {@code onDestroyView} method of a fragment.
-   *
-   * @param target Target class for field unbind.
-   */
-  public static void unbind(Object target) {
-    Class<?> targetClass = target.getClass();
-    try {
-      if (debug) Log.d(TAG, "Looking up view binder for " + targetClass.getName());
-      ViewBinder<Object> viewBinder = findViewBinderForClass(targetClass);
-      if (viewBinder != null) {
-        viewBinder.unbind(target);
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to unbind views for " + targetClass.getName(), e);
-    }
   }
 
   static void bind(Object target, Object source, Finder finder) {

--- a/butterknife/src/main/java/butterknife/internal/ViewBinder.java
+++ b/butterknife/src/main/java/butterknife/internal/ViewBinder.java
@@ -2,5 +2,4 @@ package butterknife.internal;
 
 public interface ViewBinder<T> {
   void bind(Finder finder, T target, Object source);
-  void unbind(T target);
 }

--- a/butterknife/src/test/java/butterknife/ButterKnifeTest.java
+++ b/butterknife/src/test/java/butterknife/ButterKnifeTest.java
@@ -175,15 +175,6 @@ public class ButterKnifeTest {
     assertThat(ButterKnife.BINDERS).containsEntry(Example.class, ButterKnife.NOP_VIEW_BINDER);
   }
 
-  @Test public void zeroBindingsUnbindDoesNotThrowException() {
-    class Example {
-    }
-
-    Example example = new Example();
-    ButterKnife.unbind(example);
-    assertThat(ButterKnife.BINDERS).containsEntry(Example.class, ButterKnife.NOP_VIEW_BINDER);
-  }
-
   @Test public void bindingKnownPackagesIsNoOp() {
     ButterKnife.bind(new Activity());
     assertThat(ButterKnife.BINDERS).isEmpty();

--- a/website/index.html
+++ b/website/index.html
@@ -161,10 +161,11 @@ public void pickDoor(DoorView door) {
 </pre>
 
             <h4 id="reset">Binding Reset</h4>
-            <p>Fragments have a different view lifecycle than activities. When binding a fragment in <code>onCreateView</code>, set the views to <code>null</code> in <code>onDestroyView</code>. Butter Knife has an <code>unbind</code> method to do this automatically.</p>
+            <p>Fragments have a different view lifecycle than activities. When binding a fragment in <code>onCreateView</code>, set the views to <code>null</code> in <code>onDestroyView</code>. Butter Knife provides an <code>ButterKnife.Unbinder</code> interface which has an <code>unbind</code> method to do this automatically. Simply bind an unbinder with <code>@Unbinder</code> to the fragment.</p>
             <pre class="prettyprint">public class FancyFragment extends Fragment {
   @Bind(R.id.button1) Button button1;
   @Bind(R.id.button2) Button button2;
+  @Unbinder ButterKnife.Unbinder unbinder;
 
   @Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     View view = inflater.inflate(R.layout.fancy_fragment, container, false);
@@ -175,7 +176,7 @@ public void pickDoor(DoorView door) {
 
   @Override public void onDestroyView() {
     super.onDestroyView();
-    ButterKnife.unbind(this);
+    unbinder.unbind();
   }
 }</pre>
 


### PR DESCRIPTION
- Split bind and unbind logic in two separate abstractions.
- Null method bindings in generated unbind method(Closes #211).
- Update webpage to reflect the change.