### PR TITLE
Add back Optional for methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ or Gradle:
 ```groovy
 buildscript {
   dependencies {
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.6'
+    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
   }
 }
 

--- a/butterknife-annotations/src/main/java/butterknife/Optional.java
+++ b/butterknife-annotations/src/main/java/butterknife/Optional.java
@@ -1,0 +1,17 @@
+package butterknife;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Denote that the view specified by the injection is not required to be present.
+ * <pre><code>
+ * {@literal @}Optional @OnClick(R.id.subtitle) void onSubtitleClick;
+ * </code></pre>
+ */
+@Retention(CLASS) @Target(METHOD)
+public @interface Optional {
+}

--- a/butterknife-annotations/src/main/java/butterknife/Optional.java
+++ b/butterknife-annotations/src/main/java/butterknife/Optional.java
@@ -9,7 +9,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * Denote that the view specified by the injection is not required to be present.
  * <pre><code>
- * {@literal @}Optional @OnClick(R.id.subtitle) void onSubtitleClick;
+ * {@literal @}Optional @OnClick(R.id.subtitle) void onSubtitleClick() {}
  * </code></pre>
  */
 @Retention(CLASS) @Target(METHOD)

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -875,7 +875,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
 
     int[] ids = (int[]) annotationValue.invoke(annotation);
     String name = executableElement.getSimpleName().toString();
-    boolean required = isRequiredBinding(element);
+    boolean required = isOptionalBinding(element);
 
     // Verify that the method and its containing class are accessible via generated code.
     boolean hasError = isInaccessibleViaGeneratedCode(annotationClass, "methods", element);
@@ -900,7 +900,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
       if (id == NO_ID) {
         if (ids.length == 1) {
           if (!required) {
-            error(element, "ID-free binding must not be annotated with @Nullable or @Optional. (%s.%s)",
+            error(element, "ID-free binding must not be annotated with @Optional. (%s.%s)",
                 enclosingElement.getQualifiedName(), element.getSimpleName());
             hasError = true;
           }
@@ -1147,19 +1147,21 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     return elementUtils.getPackageOf(type).getQualifiedName().toString();
   }
 
-  private static boolean hasAnnotationWithNames(Element element, String... simpleNames) {
+  private static boolean hasAnnotationWithName(Element element, String simpleName) {
     for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
       String annotationName = mirror.getAnnotationType().asElement().getSimpleName().toString();
-      for (String simpleName : simpleNames) {
-        if (simpleName.equals(annotationName)) {
-          return true;
-        }
+      if (simpleName.equals(annotationName)) {
+        return true;
       }
     }
     return false;
   }
 
   private static boolean isRequiredBinding(Element element) {
-    return !hasAnnotationWithNames(element, NULLABLE_ANNOTATION_NAME, OPTIONAL_ANNOTATION_NAME);
+    return !hasAnnotationWithName(element, NULLABLE_ANNOTATION_NAME);
+  }
+
+  private static boolean isOptionalBinding(Element element) {
+    return !hasAnnotationWithName(element, OPTIONAL_ANNOTATION_NAME);
   }
 }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -1,31 +1,9 @@
 package butterknife.compiler;
 
-import butterknife.Bind;
-import butterknife.BindArray;
-import butterknife.BindBitmap;
-import butterknife.BindBool;
-import butterknife.BindColor;
-import butterknife.BindDimen;
-import butterknife.BindDrawable;
-import butterknife.BindInt;
-import butterknife.BindString;
-import butterknife.Unbinder;
-import butterknife.OnCheckedChanged;
-import butterknife.OnClick;
-import butterknife.OnEditorAction;
-import butterknife.OnFocusChange;
-import butterknife.OnItemClick;
-import butterknife.OnItemLongClick;
-import butterknife.OnItemSelected;
-import butterknife.OnLongClick;
-import butterknife.OnPageChange;
-import butterknife.OnTextChanged;
-import butterknife.OnTouch;
-import butterknife.internal.ListenerClass;
-import butterknife.internal.ListenerMethod;
 import com.google.auto.common.SuperficialValidation;
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.TypeName;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -40,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -60,6 +39,30 @@ import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import butterknife.Bind;
+import butterknife.BindArray;
+import butterknife.BindBitmap;
+import butterknife.BindBool;
+import butterknife.BindColor;
+import butterknife.BindDimen;
+import butterknife.BindDrawable;
+import butterknife.BindInt;
+import butterknife.BindString;
+import butterknife.OnCheckedChanged;
+import butterknife.OnClick;
+import butterknife.OnEditorAction;
+import butterknife.OnFocusChange;
+import butterknife.OnItemClick;
+import butterknife.OnItemLongClick;
+import butterknife.OnItemSelected;
+import butterknife.OnLongClick;
+import butterknife.OnPageChange;
+import butterknife.OnTextChanged;
+import butterknife.OnTouch;
+import butterknife.Unbinder;
+import butterknife.internal.ListenerClass;
+import butterknife.internal.ListenerMethod;
+
 import static javax.lang.model.element.ElementKind.CLASS;
 import static javax.lang.model.element.ElementKind.INTERFACE;
 import static javax.lang.model.element.ElementKind.METHOD;
@@ -77,6 +80,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
   private static final String DRAWABLE_TYPE = "android.graphics.drawable.Drawable";
   private static final String TYPED_ARRAY_TYPE = "android.content.res.TypedArray";
   private static final String NULLABLE_ANNOTATION_NAME = "Nullable";
+  private static final String OPTIONAL_ANNOTATION_NAME = "Optional";
   private static final String ITERABLE_TYPE = "java.lang.Iterable<?>";
   private static final String STRING_TYPE = "java.lang.String";
   private static final String UNBINDER_TYPE = "butterknife.ButterKnife.Unbinder<?>";
@@ -896,7 +900,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
       if (id == NO_ID) {
         if (ids.length == 1) {
           if (!required) {
-            error(element, "ID-free binding must not be annotated with @Nullable. (%s.%s)",
+            error(element, "ID-free binding must not be annotated with @Nullable or @Optional. (%s.%s)",
                 enclosingElement.getQualifiedName(), element.getSimpleName());
             hasError = true;
           }
@@ -1143,17 +1147,19 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     return elementUtils.getPackageOf(type).getQualifiedName().toString();
   }
 
-  private static boolean hasAnnotationWithName(Element element, String simpleName) {
+  private static boolean hasAnnotationWithNames(Element element, String... simpleNames) {
     for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
       String annotationName = mirror.getAnnotationType().asElement().getSimpleName().toString();
-      if (simpleName.equals(annotationName)) {
-        return true;
+      for (String simpleName : simpleNames) {
+        if (simpleName.equals(annotationName)) {
+          return true;
+        }
       }
     }
     return false;
   }
 
   private static boolean isRequiredBinding(Element element) {
-    return !hasAnnotationWithName(element, NULLABLE_ANNOTATION_NAME);
+    return !hasAnnotationWithNames(element, NULLABLE_ANNOTATION_NAME, OPTIONAL_ANNOTATION_NAME);
   }
 }

--- a/butterknife-compiler/src/test/java/butterknife/BindTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindTest.java
@@ -543,7 +543,7 @@ public class BindTest {
         .processedWith(new ButterKnifeProcessor())
         .failsToCompile()
         .withErrorContaining(
-            ("ID-free binding must not be annotated with @Nullable or @Optional. (test.Test.doStuff)"))
+            ("ID-free binding must not be annotated with @Optional. (test.Test.doStuff)"))
         .in(source)
         .onLine(7);
   }

--- a/butterknife-compiler/src/test/java/butterknife/BindTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindTest.java
@@ -1,10 +1,13 @@
 package butterknife;
 
-import butterknife.compiler.ButterKnifeProcessor;
 import com.google.common.base.Joiner;
 import com.google.testing.compile.JavaFileObjects;
-import javax.tools.JavaFileObject;
+
 import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+import butterknife.compiler.ButterKnifeProcessor;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -527,9 +530,9 @@ public class BindTest {
             "import android.content.Context;",
             "import android.view.View;",
             "import butterknife.OnClick;",
+            "import butterknife.Optional;",
             "public class Test extends View {",
-            "  @interface Nullable {}",
-            "  @Nullable @OnClick void doStuff() {}",
+            "  @Optional @OnClick void doStuff() {}",
             "  public Test(Context context) {",
             "    super(context);",
             "  }",
@@ -540,7 +543,7 @@ public class BindTest {
         .processedWith(new ButterKnifeProcessor())
         .failsToCompile()
         .withErrorContaining(
-            ("ID-free binding must not be annotated with @Nullable. (test.Test.doStuff)"))
+            ("ID-free binding must not be annotated with @Nullable or @Optional. (test.Test.doStuff)"))
         .in(source)
         .onLine(7);
   }

--- a/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
@@ -1,10 +1,13 @@
 package butterknife;
 
-import butterknife.compiler.ButterKnifeProcessor;
 import com.google.common.base.Joiner;
 import com.google.testing.compile.JavaFileObjects;
-import javax.tools.JavaFileObject;
+
 import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+import butterknife.compiler.ButterKnifeProcessor;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -286,9 +289,9 @@ public class OnClickTest {
         "package test;",
         "import android.app.Activity;",
         "import butterknife.OnClick;",
+        "import butterknife.Optional;",
         "public class Test extends Activity {",
-        "  @interface Nullable {}",
-        "  @Nullable @OnClick(1) void doStuff() {}",
+        "  @Optional @OnClick(1) void doStuff() {}",
         "}"));
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
@@ -329,10 +332,10 @@ public class OnClickTest {
         "import android.view.View;",
         "import butterknife.Bind;",
         "import butterknife.OnClick;",
+        "import butterknife.Optional;",
         "public class Test extends Activity {",
-        "  @interface Nullable {}",
         "  @Bind(1) View view;",
-        "  @Nullable @OnClick(1) void doStuff() {}",
+        "  @Optional @OnClick(1) void doStuff() {}",
         "}"));
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",

--- a/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
@@ -1,10 +1,13 @@
 package butterknife;
 
-import butterknife.compiler.ButterKnifeProcessor;
 import com.google.common.base.Joiner;
 import com.google.testing.compile.JavaFileObjects;
-import javax.tools.JavaFileObject;
+
 import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+import butterknife.compiler.ButterKnifeProcessor;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -196,11 +199,11 @@ public class UnbinderTest {
               "import android.support.v4.app.Fragment;",
               "import butterknife.ButterKnife;",
               "import butterknife.OnClick;",
+              "import butterknife.Optional;",
               "import butterknife.Unbinder;",
               "public class Test extends Fragment {",
-              "  @interface Nullable {}",
               "  @Unbinder ButterKnife.Unbinder unbinder;",
-              "  @Nullable @OnClick(1) void doStuff() {",
+              "  @Optional @OnClick(1) void doStuff() {",
               "  }",
               "}"
           ));

--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -10,11 +10,13 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 import android.util.Property;
 import android.view.View;
-import butterknife.internal.Finder;
-import butterknife.internal.ViewBinder;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import butterknife.internal.Finder;
+import butterknife.internal.ViewBinder;
 
 /**
  * Field and method binding for Android views. Use this class to simplify finding views and
@@ -66,7 +68,8 @@ import java.util.Map;
  * <p>
  * Be default, views are required to be present in the layout for both field and method bindings.
  * If a view is optional add a {@code @Nullable} annotation such as the one in the
- * <a href="http://tools.android.com/tech-docs/support-annotations">support-annotations</a> library.
+ * <a href="http://tools.android.com/tech-docs/support-annotations">support-annotations</a> library
+ * for fields, or {@code @Optional} for methods.
  * <pre><code>
  * {@literal @}Nullable @Bind(R.id.title) TextView subtitleView;
  * </code></pre>

--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -69,7 +69,7 @@ import butterknife.internal.ViewBinder;
  * Be default, views are required to be present in the layout for both field and method bindings.
  * If a view is optional add a {@code @Nullable} annotation such as the one in the
  * <a href="http://tools.android.com/tech-docs/support-annotations">support-annotations</a> library
- * for fields, or {@code @Optional} for methods.
+ * for fields or {@code @Optional} for methods.
  * <pre><code>
  * {@literal @}Nullable @Bind(R.id.title) TextView subtitleView;
  * </code></pre>

--- a/butterknife/src/main/java/butterknife/internal/Finder.java
+++ b/butterknife/src/main/java/butterknife/internal/Finder.java
@@ -54,7 +54,8 @@ public enum Finder {
           + id
           + " for "
           + who
-          + " was not found. If this view is optional add '@Nullable' (fields) or '@Optional' (methods) annotation.");
+          + " was not found. If this view is optional add '@Nullable' (fields) or '@Optional'"
+          + " (methods) annotation.");
     }
     return view;
   }

--- a/butterknife/src/main/java/butterknife/internal/Finder.java
+++ b/butterknife/src/main/java/butterknife/internal/Finder.java
@@ -54,7 +54,7 @@ public enum Finder {
           + id
           + " for "
           + who
-          + " was not found. If this view is optional add '@Nullable' annotation.");
+          + " was not found. If this view is optional add '@Nullable' (fields) or '@Optional' (methods) annotation.");
     }
     return view;
   }

--- a/butterknife/src/test/java/butterknife/internal/FinderTest.java
+++ b/butterknife/src/test/java/butterknife/internal/FinderTest.java
@@ -1,12 +1,14 @@
 package butterknife.internal;
 
 import android.view.View;
-import butterknife.shadow.EditModeShadowView;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import butterknife.shadow.EditModeShadowView;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
@@ -22,7 +24,7 @@ public final class FinderTest {
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Required view 'button1' with ID "
           + android.R.id.button1
-          + " for yo mama was not found. If this view is optional add '@Nullable' annotation.");
+          + " for yo mama was not found. If this view is optional add '@Nullable' (fields) or '@Optional' (methods) annotation.");
     }
   }
 
@@ -35,7 +37,7 @@ public final class FinderTest {
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Required view '<unavailable while editing>' "
           + "with ID " + android.R.id.button1
-          + " for yo mama was not found. If this view is optional add '@Nullable' annotation.");
+          + " for yo mama was not found. If this view is optional add '@Nullable' (fields) or '@Optional' (methods) annotation.");
     }
   }
 }

--- a/website/index.html
+++ b/website/index.html
@@ -182,11 +182,11 @@ public void pickDoor(DoorView door) {
 
             <h4 id="optional">Optional Bindings</h4>
             <p>By default, both <code>@Bind</code> and listener bindings are required. An exception will be thrown if the target view cannot be found.</p>
-            <p>To suppress this behavior and create an optional binding, add a <code>@Nullable</code> annotation to the field or method.</p>
-            <p>Note: Any annotation named <code>@Nullable</code> can be used for this purpose. It is encouraged to use the <code>@Nullable</code> annotation from Android's "support-annotations" library, see <a href="http://tools.android.com/tech-docs/support-annotations">Android Tools Project</a>.</p>
+            <p>To suppress this behavior and create an optional binding, add a <code>@Nullable</code> (fields) or <code>@Optional</code> (methods) annotation.</p>
+            <p>Note: Any annotation named <code>@Nullable</code> or <code>@Optional</code> can be used for this purpose. It is encouraged to use the <code>@Nullable</code> annotation from Android's "support-annotations" library, see <a href="http://tools.android.com/tech-docs/support-annotations">Android Tools Project</a>.</p>
             <pre class="prettyprint">@Nullable @Bind(R.id.might_not_be_there) TextView mightNotBeThere;
 
-@Nullable @OnClick(R.id.maybe_missing) void onMaybeMissingClicked() {
+@Optional @OnClick(R.id.maybe_missing) void onMaybeMissingClicked() {
   // TODO ...
 }</pre>
 


### PR DESCRIPTION
Nullable is problematic on methods since some return primitive types or void, which is both confusing and something IDEs will lint as errors.

Resolves #306