### PR TITLE
Support for unbinder inheritance.

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/UnbinderBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/UnbinderBinding.java
@@ -3,7 +3,7 @@ package butterknife.compiler;
 import com.squareup.javapoet.ClassName;
 
 final class UnbinderBinding {
-  private static final String UNBINDER_SIMPLE_NAME = "Unbinder";
+  public static final String UNBINDER_SIMPLE_NAME = "Unbinder";
 
   private final String unbinderFieldName;
   private final ClassName unbinderClassName;

--- a/butterknife-compiler/src/test/java/butterknife/ButterKnife.java
+++ b/butterknife-compiler/src/test/java/butterknife/ButterKnife.java
@@ -2,7 +2,7 @@ package butterknife;
 
 /** STUB! Required for test sources to compile. */
 public class ButterKnife {
-  public interface Unbinder {
+  public interface ViewUnbinder<T> {
     void unbind();
   }
 }

--- a/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
@@ -8,62 +8,78 @@ import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static java.util.Arrays.asList;
 
 public class UnbinderTest {
   @Test public void bindingUnbinder() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
-        .join(
-            "package test;",
-            "import android.support.v4.app.Fragment;",
-            "import butterknife.ButterKnife;",
-            "import butterknife.OnClick;",
-            "import butterknife.Unbinder;",
-            "public class Test extends Fragment {",
-            "  @Unbinder ButterKnife.Unbinder unbinder;",
-            "  @OnClick(1) void doStuff() {",
-            "  }",
-            "}"
-        ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @OnClick(1) void doStuff() {",
+                "  }",
+                "}"
+            ));
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.view.View;",
-            "import butterknife.ButterKnife;",
-            "import butterknife.internal.DebouncingOnClickListener;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.IllegalStateException;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override public void bind(final Finder finder, final T target, Object source) {",
-            "    Unbinder unbinder = new Unbinder(target);",
-            "    View view;",
-            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
-            "    unbinder.view1 = view;",
-            "    view.setOnClickListener(new DebouncingOnClickListener() {",
-            "      @Override public void doClick(View p0) {",
-            "        target.doStuff();",
-            "      }",
-            "    });",
-            "    target.unbinder = unbinder;",
-            "  }",
-            "  private static final class Unbinder implements ButterKnife.Unbinder {",
-            "    private Test target;",
-            "    View view1;",
-            "    Unbinder(Test target) {",
-            "      this.target = target;",
-            "    }",
-            "    @Override public void unbind() {",
-            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
-            "      view1.setOnClickListener(null);",
-            "      target.unbinder = null;",
-            "      target = null;",
-            "    }",
-            "  }",
-            "}"
-        ));
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff();",
+                "      }",
+                "    });",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      view1.setOnClickListener(null);",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -73,116 +89,134 @@ public class UnbinderTest {
   }
 
   @Test public void failWhenMultipleUnbinders() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
-        .join(
-            "package test;",
-            "import android.support.v4.app.Fragment;",
-            "import butterknife.ButterKnife;",
-            "import butterknife.Unbinder;",
-            "public class Test extends Fragment {",
-            "  @Unbinder ButterKnife.Unbinder unbinder1;",
-            "  @Unbinder ButterKnife.Unbinder unbinder2;",
-            "}"
-        ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder1;",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder2;",
+                "}"
+            ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
         .failsToCompile()
         .withErrorContaining(
             "Only one filed should be annotated with @Unbinder. (test.Test.unbinder2)")
-        .in(source).onLine(7);
+        .in(source)
+        .onLine(7);
   }
 
   @Test public void failOnWrongUnbinderType() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
-        .join(
-            "package test;",
-            "import android.support.v4.app.Fragment;",
-            "import butterknife.Unbinder;",
-            "public class Test extends Fragment {",
-            "  @Unbinder Object unbinder;",
-            "}"
-        ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder Object unbinder;",
+                "}"
+            ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
         .failsToCompile()
         .withErrorContaining(
-            "@Unbinder filed must be of type ButterKnife.Unbinder. (test.Test.unbinder)")
-        .in(source).onLine(5);
+            "@Unbinder filed must be of type ButterKnife.ViewUnbinder. (test.Test.unbinder)")
+        .in(source)
+        .onLine(5);
   }
 
   @Test public void multipleBindings() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
-        .join(
-            "package test;",
-            "import android.support.v4.app.Fragment;",
-            "import android.view.View;",
-            "import butterknife.Bind;",
-            "import butterknife.ButterKnife;",
-            "import butterknife.OnClick;",
-            "import butterknife.OnLongClick;",
-            "import butterknife.Unbinder;",
-            "public class Test extends Fragment {",
-            "  @Unbinder ButterKnife.Unbinder unbinder;",
-            "  @Bind(1) View view;",
-            "  @Bind(2) View view2;",
-            "  @OnClick(1) void doStuff() {",
-            "  }",
-            "  @OnLongClick(1) boolean doMoreStuff() { return false; }",
-            "}"
-        ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import android.view.View;",
+                "import butterknife.Bind;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.OnLongClick;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @Bind(1) View view;",
+                "  @Bind(2) View view2;",
+                "  @OnClick(1) void doStuff() {",
+                "  }",
+                "  @OnLongClick(1) boolean doMoreStuff() { return false; }",
+                "}"
+            ));
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.view.View;",
-            "import butterknife.ButterKnife;",
-            "import butterknife.internal.DebouncingOnClickListener;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.IllegalStateException;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override public void bind(final Finder finder, final T target, Object source) {",
-            "    Unbinder unbinder = new Unbinder(target);",
-            "    View view;",
-            "    view = finder.findRequiredView(source, 1, \"field 'view', method 'doStuff', and method 'doMoreStuff'\");",
-            "    target.view = view;",
-            "    unbinder.view1 = view;",
-            "    view.setOnClickListener(new DebouncingOnClickListener() {",
-            "      @Override public void doClick(View p0) {",
-            "        target.doStuff();",
-            "      }",
-            "    });",
-            "    view.setOnLongClickListener(new View.OnLongClickListener() {",
-            "      @Override public boolean onLongClick(View p0) {",
-            "        return target.doMoreStuff();",
-            "      }",
-            "    });",
-            "    view = finder.findRequiredView(source, 2, \"field 'view2'\");",
-            "    target.view2 = view;",
-            "    target.unbinder = unbinder;",
-            "  }",
-            "  private static final class Unbinder implements ButterKnife.Unbinder {",
-            "    private Test target;",
-            "    View view1;",
-            "    Unbinder(Test target) {",
-            "      this.target = target;",
-            "    }",
-            "    @Override public void unbind() {",
-            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
-            "      view1.setOnClickListener(null);",
-            "      view1.setOnLongClickListener(null);",
-            "      target.view = null;",
-            "      target.view2 = null;",
-            "      target.unbinder = null;",
-            "      target = null;",
-            "    }",
-            "  }",
-            "}"
-        ));
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"field 'view', method 'doStuff', and method 'doMoreStuff'\");",
+                "    target.view = view;",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff();",
+                "      }",
+                "    });",
+                "    view.setOnLongClickListener(new View.OnLongClickListener() {",
+                "      @Override public boolean onLongClick(View p0) {",
+                "        return target.doMoreStuff();",
+                "      }",
+                "    });",
+                "    view = finder.findRequiredView(source, 2, \"field 'view2'\");",
+                "    target.view2 = view;",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      view1.setOnClickListener(null);",
+                "      view1.setOnLongClickListener(null);",
+                "      target.view = null;",
+                "      target.view2 = null;",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -192,69 +226,575 @@ public class UnbinderTest {
   }
 
   @Test public void unbinderRespectsNullable() {
-      JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n')
-          .join(
-              "package test;",
-              "import android.support.v4.app.Fragment;",
-              "import butterknife.ButterKnife;",
-              "import butterknife.OnClick;",
-              "import butterknife.Optional;",
-              "import butterknife.Unbinder;",
-              "public class Test extends Fragment {",
-              "  @Unbinder ButterKnife.Unbinder unbinder;",
-              "  @Optional @OnClick(1) void doStuff() {",
-              "  }",
-              "}"
-          ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.Optional;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @Optional @OnClick(1) void doStuff() {",
+                "  }",
+                "}"
+            ));
 
-      JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-          Joiner.on('\n').join(
-              "package test;",
-              "import android.view.View;",
-              "import butterknife.ButterKnife;",
-              "import butterknife.internal.DebouncingOnClickListener;",
-              "import butterknife.internal.Finder;",
-              "import butterknife.internal.ViewBinder;",
-              "import java.lang.IllegalStateException;",
-              "import java.lang.Object;",
-              "import java.lang.Override;",
-              "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-              "  @Override public void bind(final Finder finder, final T target, Object source) {",
-              "    Unbinder unbinder = new Unbinder(target);",
-              "    View view;",
-              "    view = finder.findOptionalView(source, 1, null);",
-              "    if (view != null) {",
-              "      unbinder.view1 = view;",
-              "      view.setOnClickListener(new DebouncingOnClickListener() {",
-              "        @Override public void doClick(View p0) {",
-              "          target.doStuff();",
-              "        }",
-              "      });",
-              "    }",
-              "    target.unbinder = unbinder;",
-              "  }",
-              "  private static final class Unbinder implements ButterKnife.Unbinder {",
-              "    private Test target;",
-              "    View view1;",
-              "    Unbinder(Test target) {",
-              "      this.target = target;",
-              "    }",
-              "    @Override public void unbind() {",
-              "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
-              "      if (view1 != null) {",
-              "        view1.setOnClickListener(null);",
-              "      }",
-              "      target.unbinder = null;",
-              "      target = null;",
-              "    }",
-              "  }",
-              "}"
-          ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findOptionalView(source, 1, null);",
+                "    if (view != null) {",
+                "      unbinder.view1 = view;",
+                "      view.setOnClickListener(new DebouncingOnClickListener() {",
+                "        @Override public void doClick(View p0) {",
+                "          target.doStuff();",
+                "        }",
+                "      });",
+                "    }",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      if (view1 != null) {",
+                "        view1.setOnClickListener(null);",
+                "      }",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
 
-      assertAbout(javaSource()).that(source)
-          .processedWith(new ButterKnifeProcessor())
-          .compilesWithoutError()
-          .and()
-          .generatesSources(expectedSource);
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void childBindsSecondUnbinder() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @OnClick(1) void doStuff1() { }",
+                "}",
+                "class TestOne extends Test {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder2;",
+                "  @OnClick(1) void doStuff2() { }",
+                "}",
+                "class TestTwo extends Test {",
+                "}"
+            ));
+
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff1();",
+                "      }",
+                "    });",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      view1.setOnClickListener(null);",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    super.bind(finder, target, source);",
+                "    Unbinder unbinder = super.accessUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff2();",
+                "      }",
+                "    });",
+                "    target.unbinder2 = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  @Override protected <U extends Test$$ViewBinder.Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  @Override protected <U extends Test$$ViewBinder.Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder2;",
+                "  }",
+                "  public static class Unbinder<T extends TestOne> extends Test$$ViewBinder.Unbinder<T> {",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      super(target);",
+                "    }",
+                "    @Override protected void unbind(T target) {",
+                "      super.unbind(target);",
+                "      view1.setOnClickListener(null);",
+                "      target.unbinder2 = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
+  }
+
+  @Test public void childUsesOwnUnbinder() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @OnClick(1) void doStuff1() { }",
+                "}",
+                "class TestOne extends Test {",
+                "  @OnClick(1) void doStuff2() { }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff1();",
+                "      }",
+                "    });",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      view1.setOnClickListener(null);",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    super.bind(finder, target, source);",
+                "    Unbinder unbinder = super.accessUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff2();",
+                "      }",
+                "    });",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  @Override protected <U extends Test$$ViewBinder.Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  public static class Unbinder<T extends TestOne> extends Test$$ViewBinder.Unbinder<T> {",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      super(target);",
+                "    }",
+                "    @Override protected void unbind(T target) {",
+                "      super.unbind(target);",
+                "      view1.setOnClickListener(null);",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
+  }
+
+  @Test public void childInDifferentPackage() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @OnClick(1) void doStuff1() { }",
+                "}"
+            ));
+
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.one.TestOne",
+        Joiner.on('\n')
+            .join(
+                "package test.one;",
+                "import test.Test;",
+                "import butterknife.OnClick;",
+                "class TestOne extends Test {",
+                "  @OnClick(2) void doStuff2() { }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff1();",
+                "      }",
+                "    });",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      view1.setOnClickListener(null);",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/one/TestOne$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test.one;",
+                "import android.view.View;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "import test.Test$$ViewBinder;",
+                "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    super.bind(finder, target, source);",
+                "    Unbinder unbinder = super.accessUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 2, \"method 'doStuff2'\");",
+                "    unbinder.view2 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff2();",
+                "      }",
+                "    });",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  @Override protected <U extends Test$$ViewBinder.Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  public static class Unbinder<T extends TestOne> extends Test$$ViewBinder.Unbinder<T> {",
+                "    View view2;",
+                "    protected Unbinder(T target) {",
+                "      super(target);",
+                "    }",
+                "    @Override protected void unbind(T target) {",
+                "      super.unbind(target);",
+                "      view2.setOnClickListener(null);",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    assertAbout(javaSources()).that(asList(source1, source2))
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
+  }
+
+  @Test public void unbindingThroughAbstractChild() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.support.v4.app.Fragment;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.OnClick;",
+                "import butterknife.Unbinder;",
+                "public class Test extends Fragment {",
+                "  @Unbinder ButterKnife.ViewUnbinder unbinder;",
+                "  @OnClick(1) void doStuff1() { }",
+                "}",
+                "class TestOne extends Test {",
+                "}",
+                "class TestTwo extends TestOne {",
+                "  @OnClick(1) void doStuff2() { }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.ButterKnife;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import butterknife.internal.ViewBinder;",
+                "import java.lang.IllegalStateException;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    Unbinder unbinder = createUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff1();",
+                "      }",
+                "    });",
+                "    target.unbinder = unbinder;",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  protected <U extends Unbinder<T>> U accessUnbinder(T target) {",
+                "    return (U) target.unbinder;",
+                "  }",
+                "  public static class Unbinder<T extends Test> implements ButterKnife.ViewUnbinder<T> {",
+                "    private T target;",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      this.target = target;",
+                "    }",
+                "    @Override public final void unbind() {",
+                "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+                "      unbind(target);",
+                "      target = null;",
+                "    }",
+                "    protected void unbind(T target) {",
+                "      view1.setOnClickListener(null);",
+                "      target.unbinder = null;",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestTwo$$ViewBinder",
+        Joiner.on('\n')
+            .join(
+                "package test;",
+                "import android.view.View;",
+                "import butterknife.internal.DebouncingOnClickListener;",
+                "import butterknife.internal.Finder;",
+                "import java.lang.Object;",
+                "import java.lang.Override;",
+                "import java.lang.SuppressWarnings;",
+                "public class TestTwo$$ViewBinder<T extends TestTwo> extends Test$$ViewBinder<T> {",
+                "  @Override public void bind(final Finder finder, final T target, Object source) {",
+                "    super.bind(finder, target, source);",
+                "    Unbinder unbinder = super.accessUnbinder(target);",
+                "    View view;",
+                "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");",
+                "    unbinder.view1 = view;",
+                "    view.setOnClickListener(new DebouncingOnClickListener() {",
+                "      @Override public void doClick(View p0) {",
+                "        target.doStuff2();",
+                "      }",
+                "    });",
+                "  }",
+                "  @SuppressWarnings(\"unchecked\")",
+                "  @Override protected <U extends Test$$ViewBinder.Unbinder<T>> U createUnbinder(T target) {",
+                "    return (U) new Unbinder(target);",
+                "  }",
+                "  public static class Unbinder<T extends TestTwo> extends Test$$ViewBinder.Unbinder<T> {",
+                "    View view1;",
+                "    protected Unbinder(T target) {",
+                "      super(target);",
+                "    }",
+                "    @Override protected void unbind(T target) {",
+                "      super.unbind(target);",
+                "      view1.setOnClickListener(null);",
+                "    }",
+                "  }",
+                "}"
+            ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
   }
 }

--- a/butterknife-sample/src/main/AndroidManifest.xml
+++ b/butterknife-sample/src/main/AndroidManifest.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.butterknife">
 
   <application
       android:allowBackup="false"
+      android:fullBackupContent="false"
       android:label="@string/app_name"
       android:name=".SimpleApp"
-      tools:ignore="MissingApplicationIcon">
+      tools:ignore="MissingApplicationIcon,UnusedAttribute">
 
     <activity
         android:label="@string/app_name"
         android:name=".SimpleActivity">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
+
         <category android:name="android.intent.category.LAUNCHER"/>
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>

--- a/butterknife-sample/src/main/java/com/example/butterknife/SimpleActivity.java
+++ b/butterknife-sample/src/main/java/com/example/butterknife/SimpleActivity.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
+import butterknife.ButterKnife.ViewUnbinder;
 import butterknife.OnClick;
 import butterknife.OnItemClick;
 import butterknife.OnLongClick;
@@ -37,7 +38,7 @@ public class SimpleActivity extends Activity {
   @Bind(R.id.hello) Button hello;
   @Bind(R.id.list_of_things) ListView listOfThings;
   @Bind(R.id.footer) TextView footer;
-  @Unbinder ButterKnife.Unbinder unbinder;
+  @Unbinder ViewUnbinder unbinder;
 
   @Bind({ R.id.title, R.id.subtitle, R.id.hello })
   List<View> headerViews;

--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -85,7 +85,7 @@ public final class ButterKnife {
 
   /** An unbinder contract that can be bind with {@link butterknife.Unbinder}. */
   @SuppressWarnings("unused") // Used by generated code.
-  public interface Unbinder {
+  public interface ViewUnbinder<T> {
     void unbind();
   }
 

--- a/website/index.html
+++ b/website/index.html
@@ -161,11 +161,11 @@ public void pickDoor(DoorView door) {
 </pre>
 
             <h4 id="reset">Binding Reset</h4>
-            <p>Fragments have a different view lifecycle than activities. When binding a fragment in <code>onCreateView</code>, set the views to <code>null</code> in <code>onDestroyView</code>. Butter Knife provides an <code>ButterKnife.Unbinder</code> interface which has an <code>unbind</code> method to do this automatically. Simply bind an unbinder with <code>@Unbinder</code> to the fragment.</p>
+            <p>Fragments have a different view lifecycle than activities. When binding a fragment in <code>onCreateView</code>, set the views to <code>null</code> in <code>onDestroyView</code>. Butter Knife provides an <code>ButterKnife.ViewUnbinder</code> interface which has an <code>unbind</code> method to do this automatically. Simply bind a view unbinder with <code>@Unbinder</code> to the fragment.</p>
             <pre class="prettyprint">public class FancyFragment extends Fragment {
   @Bind(R.id.button1) Button button1;
   @Bind(R.id.button2) Button button2;
-  @Unbinder ButterKnife.Unbinder unbinder;
+  @Unbinder ViewUnbinder unbinder;
 
   @Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     View view = inflater.inflate(R.layout.fancy_fragment, container, false);


### PR DESCRIPTION
This address the issue raised in #390. Allows unbinders to inherit form parent `ViewBinder.ViewUnbinder`'s.

__Changes:__
* Renamed `ButterKnife.Unbinder` -> `ButerKnife.ViewUnbinder`.
* By default only the top level Unbinder (no parent case) overrides the `ButterKnife.ViewUnbinder#unbind()` method, making it final. The actual unbindings happen in `generated_source$$ViewBinder.Unbinder#unbind(T)`, this allows all child unbinders to override it not braking the expected behaviour. 
* For every "potential" parent unbinder we generate 2 protected helper methods in the `ViewBinder` class.
* Each child `ViewBInder` overrides at at-least the `createUnbinder` method providing he's "extended" Unbinder. 
* If a child also binds an unbinder, `accessUnbinder` will be overriden, but will be called only from the next child in the hierarchy (if any).