### PR TITLE
ViewPager listener setting

### DIFF
--- a/butterknife-annotations/src/main/java/butterknife/OnPageChange.java
+++ b/butterknife-annotations/src/main/java/butterknife/OnPageChange.java
@@ -31,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 @Retention(CLASS)
 @ListenerClass(
     targetType = "android.support.v4.view.ViewPager",
-    setter = "setOnPageChangeListener",
+    setter = "addOnPageChangeListener",
     type = "android.support.v4.view.ViewPager.OnPageChangeListener",
     callbacks = OnPageChange.Callback.class
 )

--- a/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
@@ -33,7 +33,7 @@ public class OnPageChangeTest {
             "  @Override public void bind(final Finder finder, final T target, Object source) {",
             "    View view;",
             "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
-            "    ((ViewPager) view).setOnPageChangeListener(new ViewPager.OnPageChangeListener() {",
+            "    ((ViewPager) view).addOnPageChangeListener(new ViewPager.OnPageChangeListener() {",
             "      @Override public void onPageSelected(int p0) {",
             "        target.doStuff();",
             "      }",


### PR DESCRIPTION
[`ViewPager#setOnPageChangeListener`](https://developer.android.com/reference/android/support/v4/view/ViewPager.html#setOnPageChangeListener(android.support.v4.view.ViewPager.OnPageChangeListener)) was deprecated, [`ViewPager#addOnPageChangeListener`](https://developer.android.com/reference/android/support/v4/view/ViewPager.html#addOnPageChangeListener(android.support.v4.view.ViewPager.OnPageChangeListener)) is marked as a replacement.