### PR TITLE
Explicitly turn off lint for resource bindings

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
@@ -282,11 +282,11 @@ final class BindingClass {
       for (FieldResourceBinding binding : resourceBindings) {
         // TODO being themeable is poor correlation to the need to use Utils.
         if (binding.isThemeable()) {
-          result.addStatement("target.$L = $T.$L(res, theme, $L)", binding.getName(),
-              UTILS, binding.getMethod(), binding.getId());
+          result.addStatement("/* noinspection ResourceType */ target.$L = $T.$L(res, theme, $L)",
+              binding.getName(), UTILS, binding.getMethod(), binding.getId());
         } else {
-          result.addStatement("target.$L = res.$L($L)", binding.getName(), binding.getMethod(),
-              binding.getId());
+          result.addStatement("/* noinspection ResourceType */ target.$L = res.$L($L)",
+              binding.getName(), binding.getMethod(), binding.getId());
         }
       }
     }


### PR DESCRIPTION
Lint checks resource fetches, now, to be sure that the request type matches the resource type.  It doesn't ignore raw numbers, as it probably should.  This is a workaround that does not require turning of type checking for the whole project.

All test pass.  I have not verified the output in my own test project, because I can't find the build artifact.  If you can tell me where it is, I'll do that.