### PR TITLE
Make newlines consistent in compiler unit tests.

### DIFF
--- a/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
@@ -23,24 +23,26 @@ public class BindArrayTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.res.Resources;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Resources res = finder.getContext(source).getResources();\n"
-        + "    target.one = res.getStringArray(1);\n"
-        + "    return Unbinder.EMPTY;\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.res.Resources;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    Resources res = finder.getContext(source).getResources();",
+            "    target.one = res.getStringArray(1);",
+            "    return Unbinder.EMPTY;",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
@@ -25,43 +25,45 @@ public class BindViewTest {
             "}"
         ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
-        + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
+            "    target.thing = view;",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -82,43 +84,45 @@ public class BindViewTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
-        + "    target.thing = finder.castView(view, 1, \"field 'thing'\");\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
+            "    target.thing = finder.castView(view, 1, \"field 'thing'\");",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -139,43 +143,45 @@ public class BindViewTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
-        + "    target.thing = finder.castView(view, 1, \"field 'thing'\");\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
+            "    target.thing = finder.castView(view, 1, \"field 'thing'\");",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -197,53 +203,55 @@ public class BindViewTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'thing1' and method 'doStuff'\");\n"
-        + "    target.thing1 = view;\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      target.thing1 = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'thing1' and method 'doStuff'\");",
+            "    target.thing1 = view;",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "      target.thing1 = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -282,43 +290,45 @@ public class BindViewTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findOptionalView(source, 1, null);\n"
-        + "    target.view = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.view = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findOptionalView(source, 1, null);",
+            "    target.view = view;",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.view = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -343,76 +353,80 @@ public class BindViewTest {
         "}"
     ));
 
-    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'view'\");\n"
-        + "    target.view = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.view = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'view'\");",
+            "    target.view = view;",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.view = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
-        + "// Generated code from Butter Knife. Do not modify!\n"
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
-        + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder",
+        Joiner.on('\n').join(
+            "// Generated code from Butter Knife. Do not modify!",
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
+            "    target.thing = view;",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -437,75 +451,79 @@ public class BindViewTest {
         "}"
     ));
 
-    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'view'\");\n"
-        + "    target.view = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.view = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'view'\");",
+            "    target.view = view;",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.view = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
-        + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'thing'\");",
+            "    target.thing = view;",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindViewsTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewsTest.java
@@ -40,46 +40,48 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinding", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.arrayOf(\n"
-        + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinding",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.arrayOf(",
+            "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -99,46 +101,48 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.arrayOf(\n"
-        + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", 
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.arrayOf(",
+            "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -158,47 +162,49 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.TextView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.arrayOf(\n"
-        + "        finder.<TextView>findRequiredView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<TextView>findRequiredView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<TextView>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.TextView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.arrayOf(",
+            "        finder.<TextView>findRequiredView(source, 1, \"field 'thing'\"), ",
+            "        finder.<TextView>findRequiredView(source, 2, \"field 'thing'\"), ",
+            "        finder.<TextView>findRequiredView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+    ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -219,46 +225,48 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.listOf(\n"
-        + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.listOf(",
+            "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -279,46 +287,48 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.listOf(\n"
-        + "        finder.<Test.TestInterface>findRequiredView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<Test.TestInterface>findRequiredView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<Test.TestInterface>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.listOf(",
+            "        finder.<Test.TestInterface>findRequiredView(source, 1, \"field 'thing'\"), ",
+            "        finder.<Test.TestInterface>findRequiredView(source, 2, \"field 'thing'\"), ",
+            "        finder.<Test.TestInterface>findRequiredView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -339,46 +349,48 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.listOf(\n"
-        + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.listOf(",
+            "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), ",
+            "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -400,46 +412,48 @@ public class BindViewsTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    target.thing = Utils.listOf(\n"
-        + "        finder.<View>findOptionalView(source, 1, \"field 'thing'\"), \n"
-        + "        finder.<View>findOptionalView(source, 2, \"field 'thing'\"), \n"
-        + "        finder.<View>findOptionalView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.thing = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    target.thing = Utils.listOf(",
+            "        finder.<View>findOptionalView(source, 1, \"field 'thing'\"), ",
+            "        finder.<View>findOptionalView(source, 2, \"field 'thing'\"), ",
+            "        finder.<View>findOptionalView(source, 3, \"field 'thing'\"));",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.thing = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
@@ -23,51 +23,53 @@ public class OnCheckedChangedTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.CompoundButton;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((CompoundButton) view).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {\n"
-        + "      @Override\n"
-        + "      public void onCheckedChanged(CompoundButton p0, boolean p1) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((CompoundButton) view1).setOnCheckedChangeListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.CompoundButton;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((CompoundButton) view).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {",
+            "      @Override",
+            "      public void onCheckedChanged(CompoundButton p0, boolean p1) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((CompoundButton) view1).setOnCheckedChangeListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
@@ -22,51 +22,53 @@ public class OnClickTest {
         "  @OnClick(1) void doStuff() {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -87,63 +89,65 @@ public class OnClickTest {
         "  @OnClick({1, 2}) void doStuff3(View v) {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1', method 'doStuff2', and method 'doStuff3'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff1();\n"
-        + "        target.doStuff2();\n"
-        + "        target.doStuff3(p0);\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 2, \"method 'doStuff3'\");\n"
-        + "    unbinder.view2 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff3(p0);\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    View view2;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      view2.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff1', method 'doStuff2', and method 'doStuff3'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff1();",
+            "        target.doStuff2();",
+            "        target.doStuff3(p0);",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 2, \"method 'doStuff3'\");",
+            "    unbinder.view2 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff3(p0);",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    View view2;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "      view2.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -164,53 +168,55 @@ public class OnClickTest {
         "  @OnClick(1) void doStuff() {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'view' and method 'doStuff'\");\n"
-        + "    target.view = view;\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      target.view = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'view' and method 'doStuff'\");",
+            "    target.view = view;",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "      target.view = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -255,96 +261,98 @@ public class OnClickTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.Button;\n"
-        + "import android.widget.TextView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 0, \"method 'click0'\");\n"
-        + "    unbinder.view0 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click0();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'click1'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click1(p0);\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 2, \"method 'click2'\");\n"
-        + "    unbinder.view2 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click2(finder.<TextView>castParam(p0, \"doClick\", 0, \"click2\", 0)\n"
-        + "        );\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 3, \"method 'click3'\");\n"
-        + "    unbinder.view3 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click3(finder.<Button>castParam(p0, \"doClick\", 0, \"click3\", 0)\n"
-        + "        );\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 4, \"method 'click4'\");\n"
-        + "    unbinder.view4 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click4(finder.<Test.TestInterface>castParam(p0, \"doClick\", 0, \"click4\", 0)\n"
-        + "        );\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view0;\n"
-        + "    View view1;\n"
-        + "    View view2;\n"
-        + "    View view3;\n"
-        + "    View view4;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view0.setOnClickListener(null);\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      view2.setOnClickListener(null);\n"
-        + "      view3.setOnClickListener(null);\n"
-        + "      view4.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.Button;",
+            "import android.widget.TextView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 0, \"method 'click0'\");",
+            "    unbinder.view0 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click0();",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 1, \"method 'click1'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click1(p0);",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 2, \"method 'click2'\");",
+            "    unbinder.view2 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click2(finder.<TextView>castParam(p0, \"doClick\", 0, \"click2\", 0)",
+            "        );",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 3, \"method 'click3'\");",
+            "    unbinder.view3 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click3(finder.<Button>castParam(p0, \"doClick\", 0, \"click3\", 0)",
+            "        );",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 4, \"method 'click4'\");",
+            "    unbinder.view4 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click4(finder.<Test.TestInterface>castParam(p0, \"doClick\", 0, \"click4\", 0)",
+            "        );",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view0;",
+            "    View view1;",
+            "    View view2;",
+            "    View view3;",
+            "    View view4;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view0.setOnClickListener(null);",
+            "      view1.setOnClickListener(null);",
+            "      view2.setOnClickListener(null);",
+            "      view3.setOnClickListener(null);",
+            "      view4.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -364,71 +372,73 @@ public class OnClickTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'click'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 2, \"method 'click'\");\n"
-        + "    unbinder.view2 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 3, \"method 'click'\");\n"
-        + "    unbinder.view3 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.click();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    View view2;\n"
-        + "    View view3;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      view2.setOnClickListener(null);\n"
-        + "      view3.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'click'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click();",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 2, \"method 'click'\");",
+            "    unbinder.view2 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click();",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 3, \"method 'click'\");",
+            "    unbinder.view3 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.click();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    View view2;",
+            "    View view3;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "      view2.setOnClickListener(null);",
+            "      view3.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -447,55 +457,57 @@ public class OnClickTest {
         "  @Optional @OnClick(1) void doStuff() {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findOptionalView(source, 1, null);\n"
-        + "    if (view != null) {\n"
-        + "      unbinder.view1 = view;\n"
-        + "      view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "        @Override\n"
-        + "        public void doClick(View p0) {\n"
-        + "          target.doStuff();\n"
-        + "        }\n"
-        + "      });\n"
-        + "    }\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      if (view1 != null) {\n"
-        + "        view1.setOnClickListener(null);\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findOptionalView(source, 1, null);",
+            "    if (view != null) {",
+            "      unbinder.view1 = view;",
+            "      view.setOnClickListener(new DebouncingOnClickListener() {",
+            "        @Override",
+            "        public void doClick(View p0) {",
+            "          target.doStuff();",
+            "        }",
+            "      });",
+            "    }",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      if (view1 != null) {",
+            "        view1.setOnClickListener(null);",
+            "      }",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -517,53 +529,55 @@ public class OnClickTest {
         "  @Optional @OnClick(1) void doStuff() {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'view'\");\n"
-        + "    target.view = view;\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      target.view = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'view'\");",
+            "    target.view = view;",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "      target.view = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
@@ -23,52 +23,54 @@ public class OnEditorActionTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.KeyEvent;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.TextView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((TextView) view).setOnEditorActionListener(new TextView.OnEditorActionListener() {\n"
-        + "      @Override\n"
-        + "      public boolean onEditorAction(TextView p0, int p1, KeyEvent p2) {\n"
-        + "        return target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((TextView) view1).setOnEditorActionListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.KeyEvent;",
+            "import android.view.View;",
+            "import android.widget.TextView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((TextView) view).setOnEditorActionListener(new TextView.OnEditorActionListener() {",
+            "      @Override",
+            "      public boolean onEditorAction(TextView p0, int p1, KeyEvent p2) {",
+            "        return target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((TextView) view1).setOnEditorActionListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
@@ -23,50 +23,52 @@ public class OnFocusChangeTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnFocusChangeListener(new View.OnFocusChangeListener() {\n"
-        + "      @Override\n"
-        + "      public void onFocusChange(View p0, boolean p1) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnFocusChangeListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnFocusChangeListener(new View.OnFocusChangeListener() {",
+            "      @Override",
+            "      public void onFocusChange(View p0, boolean p1) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnFocusChangeListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
@@ -23,51 +23,53 @@ public class OnItemClickTest {
         "  @OnItemClick(1) void doStuff() {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {",
+            "      @Override",
+            "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -92,51 +94,53 @@ public class OnItemClickTest {
         "  ) {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.doStuff(p0, p1, p2, p3);\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {",
+            "      @Override",
+            "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.doStuff(p0, p1, p2, p3);",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -159,53 +163,55 @@ public class OnItemClickTest {
         "  ) {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import android.widget.ListView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.doStuff(finder.<ListView>castParam(p0, \"onItemClick\", 0, \"doStuff\", 0)\n"
-        + "        , p2);\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import android.widget.ListView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {",
+            "      @Override",
+            "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.doStuff(finder.<ListView>castParam(p0, \"onItemClick\", 0, \"doStuff\", 0)",
+            "        , p2);",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -228,53 +234,55 @@ public class OnItemClickTest {
         "  ) {}",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import android.widget.ListView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.doStuff(finder.<ListView>castParam(p0, \"onItemClick\", 0, \"doStuff\", 0)\n"
-        + "        , p2);\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import android.widget.ListView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {",
+            "      @Override",
+            "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.doStuff(finder.<ListView>castParam(p0, \"onItemClick\", 0, \"doStuff\", 0)",
+            "        , p2);",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -296,51 +304,53 @@ public class OnItemClickTest {
         "  }",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = target;\n"
-        + "    unbinder.viewOriginal = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View viewOriginal;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) viewOriginal).setOnItemClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = target;",
+            "    unbinder.viewOriginal = view;",
+            "    ((AdapterView<?>) view).setOnItemClickListener(new AdapterView.OnItemClickListener() {",
+            "      @Override",
+            "      public void onItemClick(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View viewOriginal;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) viewOriginal).setOnItemClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
@@ -23,51 +23,53 @@ public class OnItemLongClickTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {\n"
-        + "      @Override\n"
-        + "      public boolean onItemLongClick(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        return target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemLongClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {",
+            "      @Override",
+            "      public boolean onItemLongClick(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        return target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemLongClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
@@ -24,54 +24,56 @@ public class OnItemSelectedTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onNothingSelected(AdapterView<?> p0) {\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {",
+            "      @Override",
+            "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.doStuff();",
+            "      }",
+            "      @Override",
+            "      public void onNothingSelected(AdapterView<?> p0) {",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -92,54 +94,56 @@ public class OnItemSelectedTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onNothingSelected(AdapterView<?> p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {",
+            "      @Override",
+            "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "      }",
+            "      @Override",
+            "      public void onNothingSelected(AdapterView<?> p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -162,55 +166,57 @@ public class OnItemSelectedTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'onItemSelected' and method 'onNothingSelected'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.onItemSelected();\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onNothingSelected(AdapterView<?> p0) {\n"
-        + "        target.onNothingSelected();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'onItemSelected' and method 'onNothingSelected'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {",
+            "      @Override",
+            "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.onItemSelected();",
+            "      }",
+            "      @Override",
+            "      public void onNothingSelected(AdapterView<?> p0) {",
+            "        target.onNothingSelected();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -233,81 +239,83 @@ public class OnItemSelectedTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.AdapterView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'onItemSelected' and method 'onNothingSelected'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.onItemSelected();\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onNothingSelected(AdapterView<?> p0) {\n"
-        + "        target.onNothingSelected();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 2, \"method 'onItemSelected'\");\n"
-        + "    unbinder.view2 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "        target.onItemSelected();\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onNothingSelected(AdapterView<?> p0) {\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 3, \"method 'onNothingSelected'\");\n"
-        + "    unbinder.view3 = view;\n"
-        + "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {\n"
-        + "      @Override\n"
-        + "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onNothingSelected(AdapterView<?> p0) {\n"
-        + "        target.onNothingSelected();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    View view2;\n"
-        + "    View view3;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
-        + "      ((AdapterView<?>) view2).setOnItemSelectedListener(null);\n"
-        + "      ((AdapterView<?>) view3).setOnItemSelectedListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import android.widget.AdapterView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'onItemSelected' and method 'onNothingSelected'\");",
+            "    unbinder.view1 = view;",
+            "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {",
+            "      @Override",
+            "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.onItemSelected();",
+            "      }",
+            "      @Override",
+            "      public void onNothingSelected(AdapterView<?> p0) {",
+            "        target.onNothingSelected();",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 2, \"method 'onItemSelected'\");",
+            "    unbinder.view2 = view;",
+            "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {",
+            "      @Override",
+            "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "        target.onItemSelected();",
+            "      }",
+            "      @Override",
+            "      public void onNothingSelected(AdapterView<?> p0) {",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 3, \"method 'onNothingSelected'\");",
+            "    unbinder.view3 = view;",
+            "    ((AdapterView<?>) view).setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {",
+            "      @Override",
+            "      public void onItemSelected(AdapterView<?> p0, View p1, int p2, long p3) {",
+            "      }",
+            "      @Override",
+            "      public void onNothingSelected(AdapterView<?> p0) {",
+            "        target.onNothingSelected();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    View view2;",
+            "    View view3;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);",
+            "      ((AdapterView<?>) view2).setOnItemSelectedListener(null);",
+            "      ((AdapterView<?>) view3).setOnItemSelectedListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
@@ -25,50 +25,52 @@ public class OnLongClickTest {
         "  }",
         "}"));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnLongClickListener(new View.OnLongClickListener() {\n"
-        + "      @Override\n"
-        + "      public boolean onLongClick(View p0) {\n"
-        + "        return target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnLongClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnLongClickListener(new View.OnLongClickListener() {",
+            "      @Override",
+            "      public boolean onLongClick(View p0) {",
+            "        return target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnLongClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
@@ -23,57 +23,59 @@ public class OnPageChangeTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.support.v4.view.ViewPager;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((ViewPager) view).setOnPageChangeListener(new ViewPager.OnPageChangeListener() {\n"
-        + "      @Override\n"
-        + "      public void onPageSelected(int p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onPageScrolled(int p0, float p1, int p2) {\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void onPageScrollStateChanged(int p0) {\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((ViewPager) view1).setOnPageChangeListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.support.v4.view.ViewPager;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((ViewPager) view).setOnPageChangeListener(new ViewPager.OnPageChangeListener() {",
+            "      @Override",
+            "      public void onPageSelected(int p0) {",
+            "        target.doStuff();",
+            "      }",
+            "      @Override",
+            "      public void onPageScrolled(int p0, float p1, int p2) {",
+            "      }",
+            "      @Override",
+            "      public void onPageScrollStateChanged(int p0) {",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((ViewPager) view1).setOnPageChangeListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
@@ -23,60 +23,62 @@ public class OnTextChangedTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.text.Editable;\n"
-        + "import android.text.TextWatcher;\n"
-        + "import android.view.View;\n"
-        + "import android.widget.TextView;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.CharSequence;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    ((TextView) view).addTextChangedListener(new TextWatcher() {\n"
-        + "      @Override\n"
-        + "      public void onTextChanged(CharSequence p0, int p1, int p2, int p3) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void beforeTextChanged(CharSequence p0, int p1, int p2, int p3) {\n"
-        + "      }\n"
-        + "      @Override\n"
-        + "      public void afterTextChanged(Editable p0) {\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      ((TextView) view1).addTextChangedListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.text.Editable;",
+            "import android.text.TextWatcher;",
+            "import android.view.View;",
+            "import android.widget.TextView;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.CharSequence;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    ((TextView) view).addTextChangedListener(new TextWatcher() {",
+            "      @Override",
+            "      public void onTextChanged(CharSequence p0, int p1, int p2, int p3) {",
+            "        target.doStuff();",
+            "      }",
+            "      @Override",
+            "      public void beforeTextChanged(CharSequence p0, int p1, int p2, int p3) {",
+            "      }",
+            "      @Override",
+            "      public void afterTextChanged(Editable p0) {",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      ((TextView) view1).addTextChangedListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
@@ -23,51 +23,53 @@ public class OnTouchTest {
         "}"
     ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.MotionEvent;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnTouchListener(new View.OnTouchListener() {\n"
-        + "      @Override\n"
-        + "      public boolean onTouch(View p0, MotionEvent p1) {\n"
-        + "        return target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnTouchListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+          "package test;",
+          "import android.view.MotionEvent;",
+          "import android.view.View;",
+          "import butterknife.Unbinder;",
+          "import butterknife.internal.Finder;",
+          "import butterknife.internal.ViewBinder;",
+          "import java.lang.IllegalStateException;",
+          "import java.lang.Object;",
+          "import java.lang.Override;",
+          "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+          "  @Override",
+          "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+          "    InnerUnbinder unbinder = createUnbinder(target);",
+          "    View view;",
+          "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+          "    unbinder.view1 = view;",
+          "    view.setOnTouchListener(new View.OnTouchListener() {",
+          "      @Override",
+          "      public boolean onTouch(View p0, MotionEvent p1) {",
+          "        return target.doStuff();",
+          "      }",
+          "    });",
+          "    return unbinder;",
+          "  }",
+          "  protected InnerUnbinder<T> createUnbinder(T target) {",
+          "    return new InnerUnbinder(target);",
+          "  }",
+          "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+          "    private T target;",
+          "    View view1;",
+          "    protected InnerUnbinder(T target) {",
+          "      this.target = target;",
+          "    }",
+          "    @Override",
+          "    public final void unbind() {",
+          "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+          "      unbind(target);",
+          "      target = null;",
+          "    }",
+          "    protected void unbind(T target) {",
+          "      view1.setOnTouchListener(null);",
+          "    }",
+          "  }",
+          "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
@@ -30,51 +30,53 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -104,63 +106,65 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"field 'view', method 'doStuff', and method 'doMoreStuff'\");\n"
-        + "    target.view = view;\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view.setOnLongClickListener(new View.OnLongClickListener() {\n"
-        + "      @Override\n"
-        + "      public boolean onLongClick(View p0) {\n"
-        + "        return target.doMoreStuff();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    view = finder.findRequiredView(source, 2, \"field 'view2'\");\n"
-        + "    target.view2 = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "      view1.setOnLongClickListener(null);\n"
-        + "      target.view = null;\n"
-        + "      target.view2 = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"field 'view', method 'doStuff', and method 'doMoreStuff'\");",
+            "    target.view = view;",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff();",
+            "      }",
+            "    });",
+            "    view.setOnLongClickListener(new View.OnLongClickListener() {",
+            "      @Override",
+            "      public boolean onLongClick(View p0) {",
+            "        return target.doMoreStuff();",
+            "      }",
+            "    });",
+            "    view = finder.findRequiredView(source, 2, \"field 'view2'\");",
+            "    target.view2 = view;",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "      view1.setOnLongClickListener(null);",
+            "      target.view = null;",
+            "      target.view2 = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -185,55 +189,57 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findOptionalView(source, 1, null);\n"
-        + "    if (view != null) {\n"
-        + "      unbinder.view1 = view;\n"
-        + "      view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "        @Override\n"
-        + "        public void doClick(View p0) {\n"
-        + "          target.doStuff();\n"
-        + "        }\n"
-        + "      });\n"
-        + "    }\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      if (view1 != null) {\n"
-        + "        view1.setOnClickListener(null);\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "}");
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findOptionalView(source, 1, null);",
+            "    if (view != null) {",
+            "      unbinder.view1 = view;",
+            "      view.setOnClickListener(new DebouncingOnClickListener() {",
+            "        @Override",
+            "        public void doClick(View p0) {",
+            "          target.doStuff();",
+            "        }",
+            "      });",
+            "    }",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      if (view1 != null) {",
+            "        view1.setOnClickListener(null);",
+            "      }",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -261,91 +267,95 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff2();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff2();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff1();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff1();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -371,91 +381,95 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff2();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff2();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff1();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff1();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -489,92 +503,96 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-            + "package test;\n"
-            + "import android.view.View;\n"
-            + "import butterknife.Unbinder;\n"
-            + "import butterknife.internal.DebouncingOnClickListener;\n"
-            + "import butterknife.internal.Finder;\n"
-            + "import butterknife.internal.ViewBinder;\n"
-            + "import java.lang.IllegalStateException;\n"
-            + "import java.lang.Object;\n"
-            + "import java.lang.Override;\n"
-            + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-            + "  @Override\n"
-            + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-            + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-            + "    View view;\n"
-            + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
-            + "    unbinder.view1 = view;\n"
-            + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-            + "      @Override\n"
-            + "      public void doClick(View p0) {\n"
-            + "        target.doStuff1();\n"
-            + "      }\n"
-            + "    });\n"
-            + "    return unbinder;\n"
-            + "  }\n"
-            + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-            + "    return new InnerUnbinder(target);\n"
-            + "  }\n"
-            + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-            + "    private T target;\n"
-            + "    View view1;\n"
-            + "    protected InnerUnbinder(T target) {\n"
-            + "      this.target = target;\n"
-            + "    }\n"
-            + "    @Override\n"
-            + "    public final void unbind() {\n"
-            + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-            + "      unbind(target);\n"
-            + "      target = null;\n"
-            + "    }\n"
-            + "    protected void unbind(T target) {\n"
-            + "      view1.setOnClickListener(null);\n"
-            + "    }\n"
-            + "  }\n"
-            + "}");
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff1();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/one/TestOne$$ViewBinder", ""
-            + "package test.one;\n"
-            + "import android.view.View;\n"
-            + "import butterknife.Unbinder;\n"
-            + "import butterknife.internal.DebouncingOnClickListener;\n"
-            + "import butterknife.internal.Finder;\n"
-            + "import java.lang.Object;\n"
-            + "import java.lang.Override;\n"
-            + "import test.Test$$ViewBinder;\n"
-            + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
-            + "  @Override\n"
-            + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-            + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-            + "    View view;\n"
-            + "    view = finder.findRequiredView(source, 2, \"method 'doStuff2'\");\n"
-            + "    unbinder.view2 = view;\n"
-            + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-            + "      @Override\n"
-            + "      public void doClick(View p0) {\n"
-            + "        target.doStuff2();\n"
-            + "      }\n"
-            + "    });\n"
-            + "    return unbinder;\n"
-            + "  }\n"
-            + "  @Override\n"
-            + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-            + "    return new InnerUnbinder(target);\n"
-            + "  }\n"
-            + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-            + "    View view2;\n"
-            + "    protected InnerUnbinder(T target) {\n"
-            + "      super(target);\n"
-            + "    }\n"
-            + "    @Override\n"
-            + "    protected void unbind(T target) {\n"
-            + "      super.unbind(target);\n"
-            + "      view2.setOnClickListener(null);\n"
-            + "    }\n"
-            + "  }\n"
-            + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/one/TestOne$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test.one;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import test.Test$$ViewBinder;",
+            "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 2, \"method 'doStuff2'\");",
+            "    unbinder.view2 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff2();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {",
+            "    View view2;",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      view2.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSources()).that(asList(source1, source2))
         .processedWith(new ButterKnifeProcessor())
@@ -602,91 +620,95 @@ public class UnbinderTest {
                 "}"
             ));
 
-    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff1();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff1();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends Test> implements Unbinder {",
+            "    private T target;",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestTwo$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "public class TestTwo$$ViewBinder<T extends TestTwo> extends Test$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");\n"
-        + "    unbinder.view1 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.doStuff2();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends TestTwo> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    View view1;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      view1.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestTwo$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "public class TestTwo$$ViewBinder<T extends TestTwo> extends Test$$ViewBinder<T> {",
+            "  @Override",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");",
+            "    unbinder.view1 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.doStuff2();",
+            "      }",
+            "    });",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends TestTwo> extends Test$$ViewBinder.InnerUnbinder<T> {",
+            "    View view1;",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      view1.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -696,380 +718,404 @@ public class UnbinderTest {
   }
 
   @Test public void fullIntegration() {
-    JavaFileObject sourceA = JavaFileObjects.forSourceString("test.A", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class A {\n"
-        + "  @BindColor(android.R.color.black) @ColorInt int blackColor;\n"
-        + "  public A(View view) {\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceA = JavaFileObjects.forSourceString("test.A", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class A {",
+        "  @BindColor(android.R.color.black) @ColorInt int blackColor;",
+        "  public A(View view) {",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceB = JavaFileObjects.forSourceString("test.B", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class B extends A {\n"
-        + "  @BindColor(android.R.color.white) @ColorInt int whiteColor;\n"
-        + "  public B(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceB = JavaFileObjects.forSourceString("test.B", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class B extends A {",
+        "  @BindColor(android.R.color.white) @ColorInt int whiteColor;",
+        "  public B(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceC = JavaFileObjects.forSourceString("test.C", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindView;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class C extends B {\n"
-        + "  @BindColor(android.R.color.transparent) @ColorInt int transparentColor;\n"
-        + "  @BindView(android.R.id.button1) View button1;\n"
-        + "  public C(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceC = JavaFileObjects.forSourceString("test.C", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindView;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class C extends B {",
+        "  @BindColor(android.R.color.transparent) @ColorInt int transparentColor;",
+        "  @BindView(android.R.id.button1) View button1;",
+        "  public C(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceD = JavaFileObjects.forSourceString("test.D", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class D extends C {\n"
-        + "  @BindColor(android.R.color.darker_gray) @ColorInt int grayColor;\n"
-        + "  public D(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceD = JavaFileObjects.forSourceString("test.D", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class D extends C {",
+        "  @BindColor(android.R.color.darker_gray) @ColorInt int grayColor;",
+        "  public D(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceE = JavaFileObjects.forSourceString("test.E", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class E extends C {\n"
-        + "  @BindColor(android.R.color.background_dark) @ColorInt int backgroundDarkColor;\n"
-        + "  public E(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceE = JavaFileObjects.forSourceString("test.E", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class E extends C {",
+        "  @BindColor(android.R.color.background_dark) @ColorInt int backgroundDarkColor;",
+        "  public E(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceF = JavaFileObjects.forSourceString("test.F", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class F extends D {\n"
-        + "  @BindColor(android.R.color.background_light) @ColorInt int backgroundLightColor;\n"
-        + "  public F(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceF = JavaFileObjects.forSourceString("test.F", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class F extends D {",
+        "  @BindColor(android.R.color.background_light) @ColorInt int backgroundLightColor;",
+        "  public F(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceG = JavaFileObjects.forSourceString("test.G", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindView;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "import butterknife.OnClick;\n"
-        + "public class G extends E {\n"
-        + "  @BindColor(android.R.color.darker_gray) @ColorInt int grayColor;\n"
-        + "  @BindView(android.R.id.button2) View button2;\n"
-        + "  public G(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "  @OnClick(android.R.id.content) public void onClick() {\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceG = JavaFileObjects.forSourceString("test.G", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindView;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "import butterknife.OnClick;",
+        "public class G extends E {",
+        "  @BindColor(android.R.color.darker_gray) @ColorInt int grayColor;",
+        "  @BindView(android.R.id.button2) View button2;",
+        "  public G(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "  @OnClick(android.R.id.content) public void onClick() {",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject sourceH = JavaFileObjects.forSourceString("test.H", ""
-        + "package test;\n"
-        + "import android.support.annotation.ColorInt;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.BindView;\n"
-        + "import butterknife.BindColor;\n"
-        + "import butterknife.ButterKnife;\n"
-        + "public class H extends G {\n"
-        + "  @BindColor(android.R.color.primary_text_dark) @ColorInt int grayColor;\n"
-        + "  @BindView(android.R.id.button3) View button3;\n"
-        + "  public H(View view) {\n"
-        + "    super(view);\n"
-        + "    ButterKnife.bind(this, view);\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject sourceH = JavaFileObjects.forSourceString("test.H", Joiner.on('\n').join(
+        "package test;",
+        "import android.support.annotation.ColorInt;",
+        "import android.view.View;",
+        "import butterknife.BindView;",
+        "import butterknife.BindColor;",
+        "import butterknife.ButterKnife;",
+        "public class H extends G {",
+        "  @BindColor(android.R.color.primary_text_dark) @ColorInt int grayColor;",
+        "  @BindView(android.R.id.button3) View button3;",
+        "  public H(View view) {",
+        "    super(view);",
+        "    ButterKnife.bind(this, view);",
+        "  }",
+        "}"
+    ));
 
-    JavaFileObject expectedSourceA = JavaFileObjects.forSourceString("test/A$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import butterknife.internal.ViewBinder;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class A$$ViewBinder<T extends A> implements ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.blackColor = Utils.getColor(res, theme, 17170444);\n"
-        + "    return Unbinder.EMPTY;\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceA = JavaFileObjects.forSourceString("test/A$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import butterknife.internal.ViewBinder;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class A$$ViewBinder<T extends A> implements ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.blackColor = Utils.getColor(res, theme, 17170444);",
+            "    return Unbinder.EMPTY;",
+            "  }",
+            "}"
+      ));
 
-    JavaFileObject expectedSourceB = JavaFileObjects.forSourceString("test/B$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class B$$ViewBinder<T extends B> extends A$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.whiteColor = Utils.getColor(res, theme, 17170443);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceB = JavaFileObjects.forSourceString("test/B$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class B$$ViewBinder<T extends B> extends A$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    Unbinder unbinder = super.bind(finder, target, source);",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.whiteColor = Utils.getColor(res, theme, 17170443);",
+            "    return unbinder;",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSourceC = JavaFileObjects.forSourceString("test/C$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.IllegalStateException;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class C$$ViewBinder<T extends C> extends B$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    super.bind(finder, target, source);\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 16908313, \"field 'button1'\");\n"
-        + "    target.button1 = view;\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.transparentColor = Utils.getColor(res, theme, 17170445);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends C> implements Unbinder {\n"
-        + "    private T target;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      this.target = target;\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    public final void unbind() {\n"
-        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target);\n"
-        + "      target = null;\n"
-        + "    }\n"
-        + "    protected void unbind(T target) {\n"
-        + "      target.button1 = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceC = JavaFileObjects.forSourceString("test/C$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.IllegalStateException;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class C$$ViewBinder<T extends C> extends B$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    super.bind(finder, target, source);",
+            "    InnerUnbinder unbinder = createUnbinder(target);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 16908313, \"field 'button1'\");",
+            "    target.button1 = view;",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.transparentColor = Utils.getColor(res, theme, 17170445);",
+            "    return unbinder;",
+            "  }",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends C> implements Unbinder {",
+            "    private T target;",
+            "    protected InnerUnbinder(T target) {",
+            "      this.target = target;",
+            "    }",
+            "    @Override",
+            "    public final void unbind() {",
+            "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");",
+            "      unbind(target);",
+            "      target = null;",
+            "    }",
+            "    protected void unbind(T target) {",
+            "      target.button1 = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSourceD = JavaFileObjects.forSourceString("test/D$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class D$$ViewBinder<T extends D> extends C$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.grayColor = Utils.getColor(res, theme, 17170432);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceD = JavaFileObjects.forSourceString("test/D$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class D$$ViewBinder<T extends D> extends C$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    Unbinder unbinder = super.bind(finder, target, source);",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.grayColor = Utils.getColor(res, theme, 17170432);",
+            "    return unbinder;",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSourceE = JavaFileObjects.forSourceString("test/E$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class E$$ViewBinder<T extends E> extends C$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.backgroundDarkColor = Utils.getColor(res, theme, 17170446);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceE = JavaFileObjects.forSourceString("test/E$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class E$$ViewBinder<T extends E> extends C$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    Unbinder unbinder = super.bind(finder, target, source);",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.backgroundDarkColor = Utils.getColor(res, theme, 17170446);",
+            "    return unbinder;",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSourceF = JavaFileObjects.forSourceString("test/F$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class F$$ViewBinder<T extends F> extends D$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.backgroundLightColor = Utils.getColor(res, theme, 17170447);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceF = JavaFileObjects.forSourceString("test/F$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class F$$ViewBinder<T extends F> extends D$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    Unbinder unbinder = super.bind(finder, target, source);",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.backgroundLightColor = Utils.getColor(res, theme, 17170447);",
+            "    return unbinder;",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSourceG = JavaFileObjects.forSourceString("test/G$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.DebouncingOnClickListener;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class G$$ViewBinder<T extends G> extends E$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 16908314, \"field 'button2'\");\n"
-        + "    target.button2 = view;\n"
-        + "    view = finder.findRequiredView(source, 16908290, \"method 'onClick'\");\n"
-        + "    unbinder.view16908290 = view;\n"
-        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-        + "      @Override\n"
-        + "      public void doClick(View p0) {\n"
-        + "        target.onClick();\n"
-        + "      }\n"
-        + "    });\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.grayColor = Utils.getColor(res, theme, 17170432);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends G> extends C$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    View view16908290;\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      target.button2 = null;\n"
-        + "      view16908290.setOnClickListener(null);\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceG = JavaFileObjects.forSourceString("test/G$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.DebouncingOnClickListener;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class G$$ViewBinder<T extends G> extends E$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 16908314, \"field 'button2'\");",
+            "    target.button2 = view;",
+            "    view = finder.findRequiredView(source, 16908290, \"method 'onClick'\");",
+            "    unbinder.view16908290 = view;",
+            "    view.setOnClickListener(new DebouncingOnClickListener() {",
+            "      @Override",
+            "      public void doClick(View p0) {",
+            "        target.onClick();",
+            "      }",
+            "    });",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.grayColor = Utils.getColor(res, theme, 17170432);",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends G> extends C$$ViewBinder.InnerUnbinder<T> {",
+            "    View view16908290;",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      target.button2 = null;",
+            "      view16908290.setOnClickListener(null);",
+            "    }",
+            "  }",
+            "}"
+        ));
 
-    JavaFileObject expectedSourceH = JavaFileObjects.forSourceString("test/H$$ViewBinder", ""
-        + "package test;\n"
-        + "import android.content.Context;\n"
-        + "import android.content.res.Resources;\n"
-        + "import android.view.View;\n"
-        + "import butterknife.Unbinder;\n"
-        + "import butterknife.internal.Finder;\n"
-        + "import butterknife.internal.Utils;\n"
-        + "import java.lang.Object;\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.SuppressWarnings;\n"
-        + "public class H$$ViewBinder<T extends H> extends G$$ViewBinder<T> {\n"
-        + "  @Override\n"
-        + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-        + "    View view;\n"
-        + "    view = finder.findRequiredView(source, 16908315, \"field 'button3'\");\n"
-        + "    target.button3 = view;\n"
-        + "    Context context = finder.getContext(source);\n"
-        + "    Resources res = context.getResources();\n"
-        + "    Resources.Theme theme = context.getTheme();\n"
-        + "    target.grayColor = Utils.getColor(res, theme, 17170433);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
-        + "  }\n"
-        + "  protected static class InnerUnbinder<T extends H> extends G$$ViewBinder.InnerUnbinder<T> {\n"
-        + "    protected InnerUnbinder(T target) {\n"
-        + "      super(target);\n"
-        + "    }\n"
-        + "    @Override\n"
-        + "    protected void unbind(T target) {\n"
-        + "      super.unbind(target);\n"
-        + "      target.button3 = null;\n"
-        + "    }\n"
-        + "  }\n"
-        + "}\n");
+    JavaFileObject expectedSourceH = JavaFileObjects.forSourceString("test/H$$ViewBinder",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.content.Context;",
+            "import android.content.res.Resources;",
+            "import android.view.View;",
+            "import butterknife.Unbinder;",
+            "import butterknife.internal.Finder;",
+            "import butterknife.internal.Utils;",
+            "import java.lang.Object;",
+            "import java.lang.Override;",
+            "import java.lang.SuppressWarnings;",
+            "public class H$$ViewBinder<T extends H> extends G$$ViewBinder<T> {",
+            "  @Override",
+            "  @SuppressWarnings(\"ResourceType\")",
+            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
+            "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);",
+            "    View view;",
+            "    view = finder.findRequiredView(source, 16908315, \"field 'button3'\");",
+            "    target.button3 = view;",
+            "    Context context = finder.getContext(source);",
+            "    Resources res = context.getResources();",
+            "    Resources.Theme theme = context.getTheme();",
+            "    target.grayColor = Utils.getColor(res, theme, 17170433);",
+            "    return unbinder;",
+            "  }",
+            "  @Override",
+            "  protected InnerUnbinder<T> createUnbinder(T target) {",
+            "    return new InnerUnbinder(target);",
+            "  }",
+            "  protected static class InnerUnbinder<T extends H> extends G$$ViewBinder.InnerUnbinder<T> {",
+            "    protected InnerUnbinder(T target) {",
+            "      super(target);",
+            "    }",
+            "    @Override",
+            "    protected void unbind(T target) {",
+            "      super.unbind(target);",
+            "      target.button3 = null;",
+            "    }",
+            "  }",
+            "}"
+        ));
 
     assertAbout(javaSources())
         .that(asList(sourceA,


### PR DESCRIPTION
This PR makes use of `Joiner.on('\n').join` rather than adding a `\n` to the end of every line in tests.
There were a few tests that used both methods, now they all use the same.

I noticed that checkstyle must not be taking the test source set into account.
