### PR TITLE
Improve performance of generated code (part 1).

### DIFF
--- a/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindArrayTest {
   @Test public void stringArray() throws Exception {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindArray;",
-        "public class Test extends Activity {",
-        "  @BindArray(1) String[] one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindArray;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindArray(1) String[] one;\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -34,11 +30,94 @@ public class BindArrayTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    Resources res = finder.getContext(source).getResources();\n"
         + "    target.one = res.getStringArray(1);\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void intArray() throws Exception {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindArray;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindArray(1) int[] one;\n"
+        + "}"
+    );
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
         + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getIntArray(1);\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void textArray() throws Exception {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindArray;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindArray(1) CharSequence[] one;\n"
+        + "}"
+    );
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getTextArray(1);\n"
         + "  }\n"
         + "}");
 
@@ -49,113 +128,39 @@ public class BindArrayTest {
         .generatesSources(expectedSource);
   }
 
-  @Test public void intArray() throws Exception {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindArray;",
-        "public class Test extends Activity {",
-        "  @BindArray(1) int[] one;",
-        "}"
-    ));
-
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getIntArray(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
-
-    assertAbout(javaSource()).that(source)
-        .processedWith(new ButterKnifeProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expectedSource);
-  }
-
-  @Test public void textArray() throws Exception {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindArray;",
-        "public class Test extends Activity {",
-        "  @BindArray(1) CharSequence[] one;",
-        "}"
-    ));
-
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getTextArray(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
-
-    assertAbout(javaSource()).that(source)
-        .processedWith(new ButterKnifeProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expectedSource);
-  }
-
   @Test public void typedArray() throws Exception {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindArray;",
-        "import android.content.res.TypedArray;",
-        "public class Test extends Activity {",
-        "  @BindArray(1) TypedArray one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindArray;\n"
+        + "import android.content.res.TypedArray;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindArray(1) TypedArray one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.obtainTypedArray(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.obtainTypedArray(1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -165,14 +170,14 @@ public class BindArrayTest {
   }
 
   @Test public void typeMustBeSupported() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindArray;",
-        "public class Test extends Activity {",
-        "  @BindArray(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindArray;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindArray(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindBitmapTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindBitmapTest.java
@@ -1,50 +1,48 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindBitmapTest {
   @Test public void simple() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.graphics.Bitmap;",
-        "import butterknife.BindBitmap;",
-        "public class Test extends Activity {",
-        "  @BindBitmap(1) Bitmap one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.graphics.Bitmap;\n"
+        + "import butterknife.BindBitmap;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindBitmap(1) Bitmap one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import android.graphics.BitmapFactory;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = BitmapFactory.decodeResource(res, 1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import android.graphics.BitmapFactory;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = BitmapFactory.decodeResource(res, 1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -54,14 +52,14 @@ public class BindBitmapTest {
   }
 
   @Test public void typeMustBeBitmap() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindBitmap;",
-        "public class Test extends Activity {",
-        "  @BindBitmap(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindBitmap;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindBitmap(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindBoolTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindBoolTest.java
@@ -1,48 +1,46 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindBoolTest {
   @Test public void simple() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindBool;",
-        "public class Test extends Activity {",
-        "  @BindBool(1) boolean one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;"
+        + "import android.app.Activity;"
+        + "import butterknife.BindBool;"
+        + "public class Test extends Activity {"
+        + "  @BindBool(1) boolean one;"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getBoolean(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getBoolean(1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -52,14 +50,14 @@ public class BindBoolTest {
   }
 
   @Test public void typeMustBeBoolean() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindBool;",
-        "public class Test extends Activity {",
-        "  @BindBool(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindBool;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindBool(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindColorTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindColorTest.java
@@ -1,52 +1,50 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindColorTest {
   @Test public void simpleInt() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindColor;",
-        "public class Test extends Activity {",
-        "  @BindColor(1) int one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindColor;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindColor(1) int one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.Context;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.Utils;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Context context = finder.getContext(source);",
-            "    Resources res = context.getResources();",
-            "    Resources.Theme theme = context.getTheme();",
-            "    target.one = Utils.getColor(res, theme, 1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.Context;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.Utils;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Context context = finder.getContext(source);\n"
+        + "    Resources res = context.getResources();\n"
+        + "    Resources.Theme theme = context.getTheme();\n"
+        + "    target.one = Utils.getColor(res, theme, 1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -56,40 +54,42 @@ public class BindColorTest {
   }
 
   @Test public void simpleColorStateList() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.content.res.ColorStateList;",
-        "import butterknife.BindColor;",
-        "public class Test extends Activity {",
-        "  @BindColor(1) ColorStateList one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.content.res.ColorStateList;\n"
+        + "import butterknife.BindColor;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindColor(1) ColorStateList one;\n"
+        +"}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.Context;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.Utils;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Context context = finder.getContext(source);",
-            "    Resources res = context.getResources();",
-            "    Resources.Theme theme = context.getTheme();",
-            "    target.one = Utils.getColorStateList(res, theme, 1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.Context;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.Utils;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Context context = finder.getContext(source);\n"
+        + "    Resources res = context.getResources();\n"
+        + "    Resources.Theme theme = context.getTheme();\n"
+        + "    target.one = Utils.getColorStateList(res, theme, 1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -99,14 +99,14 @@ public class BindColorTest {
   }
 
   @Test public void typeMustBeIntOrColorStateList() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindColor;",
-        "public class Test extends Activity {",
-        "  @BindColor(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindColor;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindColor(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindDimenTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindDimenTest.java
@@ -1,48 +1,46 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindDimenTest {
   @Test public void simpleFloat() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindDimen;",
-        "public class Test extends Activity {",
-        "  @BindDimen(1) float one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindDimen;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindDimen(1) float one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getDimension(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getDimension(1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -52,35 +50,37 @@ public class BindDimenTest {
   }
 
   @Test public void simpleInt() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindDimen;",
-        "public class Test extends Activity {",
-        "  @BindDimen(1) int one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindDimen;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindDimen(1) int one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getDimensionPixelSize(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getDimensionPixelSize(1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -90,14 +90,14 @@ public class BindDimenTest {
   }
 
   @Test public void typeMustBeIntOrFloat() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindDimen;",
-        "public class Test extends Activity {",
-        "  @BindDimen(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindDimen;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindDimen(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindDrawableTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindDrawableTest.java
@@ -1,53 +1,51 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindDrawableTest {
   @Test public void simple() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.graphics.drawable.Drawable;",
-        "import butterknife.BindDrawable;",
-        "public class Test extends Activity {",
-        "  @BindDrawable(1) Drawable one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.graphics.drawable.Drawable;\n"
+        + "import butterknife.BindDrawable;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindDrawable(1) Drawable one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.Context;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.Utils;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Context context = finder.getContext(source);",
-            "    Resources res = context.getResources();",
-            "    Resources.Theme theme = context.getTheme();",
-            "    target.one = Utils.getDrawable(res, theme, 1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.Context;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.Utils;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Context context = finder.getContext(source);\n"
+        + "    Resources res = context.getResources();\n"
+        + "    Resources.Theme theme = context.getTheme();\n"
+        + "    target.one = Utils.getDrawable(res, theme, 1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -57,41 +55,42 @@ public class BindDrawableTest {
   }
 
   @Test public void withTint() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.graphics.drawable.Drawable;",
-        "import butterknife.BindDrawable;",
-        "public class Test extends Activity {",
-        "  @BindDrawable(value = 1, tint = 2) Drawable one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.graphics.drawable.Drawable;\n"
+        + "import butterknife.BindDrawable;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindDrawable(value = 1, tint = 2) Drawable one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.Context;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.Utils;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Context context = finder.getContext(source);",
-            "    Resources res = context.getResources();",
-            "    Resources.Theme theme = context.getTheme();",
-            "    target.one = Utils.getTintedDrawable(res, theme, 1, 2);",
-            "    return Unbinder.EMPTY",
-            "",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.Context;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.Utils;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Context context = finder.getContext(source);\n"
+        + "    Resources res = context.getResources();\n"
+        + "    Resources.Theme theme = context.getTheme();\n"
+        + "    target.one = Utils.getTintedDrawable(res, theme, 1, 2);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -101,14 +100,14 @@ public class BindDrawableTest {
   }
 
   @Test public void typeMustBeDrawable() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindDrawable;",
-        "public class Test extends Activity {",
-        "  @BindDrawable(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindDrawable;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindDrawable(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindIntTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindIntTest.java
@@ -1,48 +1,46 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindIntTest {
   @Test public void simple() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindInt;",
-        "public class Test extends Activity {",
-        "  @BindInt(1) int one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindInt;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindInt(1) int one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getInteger(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getInteger(1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -52,14 +50,14 @@ public class BindIntTest {
   }
 
   @Test public void typeMustBeInt() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindInt;",
-        "public class Test extends Activity {",
-        "  @BindInt(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindInt;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindInt(1) String one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindStringTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindStringTest.java
@@ -1,48 +1,46 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class BindStringTest {
   @Test public void simple() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindString;",
-        "public class Test extends Activity {",
-        "  @BindString(1) String one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindString;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindString(1) String one;\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder",
-        Joiner.on('\n').join(
-            "package test;",
-            "import android.content.res.Resources;",
-            "import butterknife.Unbinder;",
-            "import butterknife.internal.Finder;",
-            "import butterknife.internal.ViewBinder;",
-            "import java.lang.Object;",
-            "import java.lang.Override;",
-            "import java.lang.SuppressWarnings;",
-            "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {",
-            "  @Override",
-            "  @SuppressWarnings(\"ResourceType\")",
-            "  public Unbinder bind(final Finder finder, final T target, Object source) {",
-            "    Resources res = finder.getContext(source).getResources();",
-            "    target.one = res.getString(1);",
-            "    return Unbinder.EMPTY",
-            "  }",
-            "}"
-        ));
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import android.content.res.Resources;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
+        + "    Resources res = finder.getContext(source).getResources();\n"
+        + "    target.one = res.getString(1);\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -52,14 +50,14 @@ public class BindStringTest {
   }
 
   @Test public void typeMustBeString() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.BindString;",
-        "public class Test extends Activity {",
-        "  @BindString(1) boolean one;",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.BindString;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindString(1) boolean one;\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
@@ -35,15 +35,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -60,7 +59,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -92,12 +92,11 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public final class Test$$ViewBinder implements ViewBinder<Test> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final Test target, Object source) {\n"
-        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, Test target, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
+        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static final class InnerUnbinder implements Unbinder {\n"
         + "    private Test target;\n"
@@ -111,7 +110,8 @@ public class BindViewTest {
         + "      target = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -152,15 +152,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Base$$ViewBinder<T extends Base> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Base target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Base> implements Unbinder {\n"
         + "    private T target;\n"
@@ -170,14 +169,15 @@ public class BindViewTest {
         + "    @Override\n"
         + "    public final void unbind() {\n"
         + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-        + "      unbind(target)\n"
+        + "      unbind(target);\n"
         + "      target = null;\n"
         + "    }\n"
         + "    protected void unbind(T target) {\n"
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     JavaFileObject expectedTestSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -188,15 +188,11 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public final class Test$$ViewBinder extends Base$$ViewBinder<Test> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final Test target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  public Unbinder bind(Finder finder, Test target, Object source) {\n"
+        + "    Base$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder createUnbinder(Test target) {\n"
         + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static final class InnerUnbinder extends Base$$ViewBinder.InnerUnbinder<Test> {\n"
@@ -209,7 +205,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSources()).that(Arrays.asList(baseSource, testSource))
         .processedWith(new ButterKnifeProcessor())
@@ -243,15 +240,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Outer$Test$$ViewBinder<T extends Outer.Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Outer.Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Outer.Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -268,7 +264,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -300,15 +297,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -325,7 +321,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -357,15 +354,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = finder.castView(view, 1, \"field 'thing'\");\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -382,7 +378,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -414,15 +411,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = finder.castView(view, 1, \"field 'thing'\");\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -439,7 +435,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -473,8 +470,12 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing1' and method 'doStuff'\");\n"
         + "    target.thing1 = view;\n"
@@ -485,10 +486,6 @@ public class BindViewTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -507,7 +504,8 @@ public class BindViewTest {
         + "      target.thing1 = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -557,15 +555,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findOptionalView(source, 1, null);\n"
         + "    target.view = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -582,7 +579,8 @@ public class BindViewTest {
         + "      target.view = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -618,15 +616,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'view'\");\n"
         + "    target.view = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -643,10 +640,10 @@ public class BindViewTest {
         + "      target.view = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
-        + "// Generated code from Butter Knife. Do not modify!\n"
         + "package test;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
@@ -655,16 +652,15 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final TestOne target, Finder finder, Object source) {\n"
+        + "    Test$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
         + "    protected InnerUnbinder(T target) {\n"
@@ -676,7 +672,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -712,15 +709,14 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'view'\");\n"
         + "    target.view = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -737,7 +733,8 @@ public class BindViewTest {
         + "      target.view = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
         + "package test;\n"
@@ -748,16 +745,15 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final TestOne target, Finder finder, Object source) {\n"
+        + "    Test$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'thing'\");\n"
         + "    target.thing = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
         + "    protected InnerUnbinder(T target) {\n"
@@ -769,7 +765,8 @@ public class BindViewTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/BindViewsTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewsTest.java
@@ -52,17 +52,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.arrayOf(\n"
         + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -79,7 +78,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -111,17 +111,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.arrayOf(\n"
         + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -138,7 +137,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -171,17 +171,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.arrayOf(\n"
         + "        finder.<TextView>findRequiredView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<TextView>findRequiredView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<TextView>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -198,7 +197,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -231,17 +231,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.listOf(\n"
         + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -258,7 +257,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -291,17 +291,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.listOf(\n"
         + "        finder.<Test.TestInterface>findRequiredView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<Test.TestInterface>findRequiredView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<Test.TestInterface>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -318,7 +317,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -351,17 +351,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.listOf(\n"
         + "        finder.<View>findRequiredView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<View>findRequiredView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -378,7 +377,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -412,17 +412,16 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source) {\n"
         + "    View view;\n"
         + "    target.thing = Utils.listOf(\n"
         + "        finder.<View>findOptionalView(source, 1, \"field 'thing'\"), \n"
         + "        finder.<View>findOptionalView(source, 2, \"field 'thing'\"), \n"
         + "        finder.<View>findOptionalView(source, 3, \"field 'thing'\"));\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -439,7 +438,8 @@ public class BindViewsTest {
         + "      target.thing = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnCheckedChangedTest {
   @Test public void checkedChanged() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnCheckedChanged;",
-        "public class Test extends Activity {",
-        "  @OnCheckedChanged(1) void doStuff() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnCheckedChanged;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnCheckedChanged(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -35,8 +31,12 @@ public class OnCheckedChangedTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -46,10 +46,6 @@ public class OnCheckedChangedTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -67,7 +63,8 @@ public class OnCheckedChangedTest {
         + "      ((CompoundButton) view1).setOnCheckedChangeListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
@@ -14,13 +14,14 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnClickTest {
   @Test public void onClickBinding() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnClick;",
-        "public class Test extends Activity {",
-        "  @OnClick(1) void doStuff() {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnClick(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -34,8 +35,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -45,10 +50,6 @@ public class OnClickTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -66,7 +67,8 @@ public class OnClickTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -76,16 +78,17 @@ public class OnClickTest {
   }
 
   @Test public void onClickMultipleBindings() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.view.View;",
-        "import android.app.Activity;",
-        "import butterknife.OnClick;",
-        "public class Test extends Activity {",
-        "  @OnClick(1) void doStuff1() {}",
-        "  @OnClick(1) void doStuff2() {}",
-        "  @OnClick({1, 2}) void doStuff3(View v) {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.view.View;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnClick(1) void doStuff1() {}\n"
+        + "  @OnClick(1) void doStuff2() {}\n"
+        + "  @OnClick({1, 2}) void doStuff3(View v) {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -99,8 +102,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1', method 'doStuff2', and method 'doStuff3'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -120,10 +127,6 @@ public class OnClickTest {
         + "        target.doStuff3(p0);\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -143,7 +146,8 @@ public class OnClickTest {
         + "      view2.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -153,16 +157,17 @@ public class OnClickTest {
   }
 
   @Test public void findOnlyCalledOnce() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import butterknife.BindView;",
-        "import butterknife.OnClick;",
-        "public class Test extends Activity {",
-        "  @BindView(1) View view;",
-        "  @OnClick(1) void doStuff() {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.BindView;\n"
+        + "import butterknife.OnClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @BindView(1) View view;\n"
+        + "  @OnClick(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -176,8 +181,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'view' and method 'doStuff'\");\n"
         + "    target.view = view;\n"
@@ -188,10 +197,6 @@ public class OnClickTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -210,7 +215,8 @@ public class OnClickTest {
         + "      target.view = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -238,22 +244,22 @@ public class OnClickTest {
   }
 
   @Test public void methodCastsArgument() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import android.widget.Button;",
-        "import android.widget.TextView;",
-        "import butterknife.OnClick;",
-        "public class Test extends Activity {",
-        "  interface TestInterface {}",
-        "  @OnClick(0) void click0() {}",
-        "  @OnClick(1) void click1(View view) {}",
-        "  @OnClick(2) void click2(TextView view) {}",
-        "  @OnClick(3) void click3(Button button) {}",
-        "  @OnClick(4) void click4(TestInterface thing) {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.view.View;\n"
+        + "import android.widget.Button;\n"
+        + "import android.widget.TextView;\n"
+        + "import butterknife.OnClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  interface TestInterface {}\n"
+        + "  @OnClick(0) void click0() {}\n"
+        + "  @OnClick(1) void click1(View view) {}\n"
+        + "  @OnClick(2) void click2(TextView view) {}\n"
+        + "  @OnClick(3) void click3(Button button) {}\n"
+        + "  @OnClick(4) void click4(TestInterface thing) {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -269,8 +275,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 0, \"method 'click0'\");\n"
         + "    unbinder.view0 = view;\n"
@@ -315,10 +325,6 @@ public class OnClickTest {
         + "        );\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -344,7 +350,8 @@ public class OnClickTest {
         + "      view4.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -354,15 +361,15 @@ public class OnClickTest {
   }
 
   @Test public void methodWithMultipleIds() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import butterknife.OnClick;",
-        "public class Test extends Activity {",
-        "  @OnClick({1, 2, 3}) void click() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.OnClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnClick({1, 2, 3}) void click() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -376,8 +383,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'click'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -403,10 +414,6 @@ public class OnClickTest {
         + "        target.click();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -428,7 +435,8 @@ public class OnClickTest {
         + "      view3.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -459,8 +467,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findOptionalView(source, 1, null);\n"
         + "    if (view != null) {\n"
@@ -472,10 +484,6 @@ public class OnClickTest {
         + "        }\n"
         + "      });\n"
         + "    }\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -495,7 +503,8 @@ public class OnClickTest {
         + "      }\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -529,8 +538,12 @@ public class OnClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'view'\");\n"
         + "    target.view = view;\n"
@@ -541,10 +554,6 @@ public class OnClickTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -563,7 +572,8 @@ public class OnClickTest {
         + "      target.view = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnEditorActionTest {
   @Test public void editorAction() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnEditorAction;",
-        "public class Test extends Activity {",
-        "  @OnEditorAction(1) boolean doStuff() { return false; }",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnEditorAction;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnEditorAction(1) boolean doStuff() { return false; }\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -36,8 +32,12 @@ public class OnEditorActionTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -47,10 +47,6 @@ public class OnEditorActionTest {
         + "        return target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -68,7 +64,8 @@ public class OnEditorActionTest {
         + "      ((TextView) view1).setOnEditorActionListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnFocusChangeTest {
   @Test public void focusChange() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnFocusChange;",
-        "public class Test extends Activity {",
-        "  @OnFocusChange(1) void doStuff() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnFocusChange;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnFocusChange(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -34,8 +30,12 @@ public class OnFocusChangeTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -45,10 +45,6 @@ public class OnFocusChangeTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -66,7 +62,8 @@ public class OnFocusChangeTest {
         + "      view1.setOnFocusChangeListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
@@ -15,13 +15,14 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 /** This augments {@link OnClickTest} with tests that exercise callbacks with parameters. */
 public class OnItemClickTest {
   @Test public void onItemClickBinding() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnItemClick;",
-        "public class Test extends Activity {",
-        "  @OnItemClick(1) void doStuff() {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;"
+        + "import android.app.Activity;"
+        + "import butterknife.OnItemClick;"
+        + "public class Test extends Activity {"
+        + "  @OnItemClick(1) void doStuff() {}"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -35,8 +36,12 @@ public class OnItemClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -46,10 +51,6 @@ public class OnItemClickTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -67,7 +68,8 @@ public class OnItemClickTest {
         + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -77,20 +79,21 @@ public class OnItemClickTest {
   }
 
   @Test public void onItemClickBindingWithParameters() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import android.widget.AdapterView;",
-        "import butterknife.OnItemClick;",
-        "public class Test extends Activity {",
-        "  @OnItemClick(1) void doStuff(",
-        "    AdapterView<?> parent,",
-        "    View view,",
-        "    int position,",
-        "    long id",
-        "  ) {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.view.View;\n"
+        + "import android.widget.AdapterView;\n"
+        + "import butterknife.OnItemClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnItemClick(1) void doStuff(\n"
+        + "    AdapterView<?> parent,\n"
+        + "    View view,\n"
+        + "    int position,\n"
+        + "    long id\n"
+        + "  ) {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -104,8 +107,12 @@ public class OnItemClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -115,10 +122,6 @@ public class OnItemClickTest {
         + "        target.doStuff(p0, p1, p2, p3);\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -136,7 +139,8 @@ public class OnItemClickTest {
         + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -146,18 +150,19 @@ public class OnItemClickTest {
   }
 
   @Test public void onItemClickBindingWithParameterSubset() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import android.widget.ListView;",
-        "import butterknife.OnItemClick;",
-        "public class Test extends Activity {",
-        "  @OnItemClick(1) void doStuff(",
-        "    ListView parent,",
-        "    int position",
-        "  ) {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.view.View;\n"
+        + "import android.widget.ListView;\n"
+        + "import butterknife.OnItemClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnItemClick(1) void doStuff(\n"
+        + "    ListView parent,\n"
+        + "    int position\n"
+        + "  ) {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -172,8 +177,12 @@ public class OnItemClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -184,10 +193,6 @@ public class OnItemClickTest {
         + "        , p2);\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -205,7 +210,8 @@ public class OnItemClickTest {
         + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -215,18 +221,19 @@ public class OnItemClickTest {
   }
 
   @Test public void onItemClickBindingWithParameterSubsetAndGenerics() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import android.view.View;",
-        "import android.widget.ListView;",
-        "import butterknife.OnItemClick;",
-        "public class Test<T extends ListView> extends Activity {",
-        "  @OnItemClick(1) void doStuff(",
-        "    T parent,",
-        "    int position",
-        "  ) {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import android.view.View;\n"
+        + "import android.widget.ListView;\n"
+        + "import butterknife.OnItemClick;\n"
+        + "public class Test<T extends ListView> extends Activity {\n"
+        + "  @OnItemClick(1) void doStuff(\n"
+        + "    T parent,\n"
+        + "    int position\n"
+        + "  ) {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -241,8 +248,12 @@ public class OnItemClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -253,10 +264,6 @@ public class OnItemClickTest {
         + "        , p2);\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -274,7 +281,8 @@ public class OnItemClickTest {
         + "      ((AdapterView<?>) view1).setOnItemClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -284,17 +292,18 @@ public class OnItemClickTest {
   }
 
   @Test public void onClickRootViewBinding() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.content.Context;",
-        "import android.widget.ListView;",
-        "import butterknife.OnItemClick;",
-        "public class Test extends ListView {",
-        "  @OnItemClick void doStuff() {}",
-        "  public Test(Context context) {",
-        "    super(context);",
-        "  }",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.content.Context;\n"
+        + "import android.widget.ListView;\n"
+        + "import butterknife.OnItemClick;\n"
+        + "public class Test extends ListView {\n"
+        + "  @OnItemClick void doStuff() {}\n"
+        + "  public Test(Context context) {\n"
+        + "    super(context);\n"
+        + "  }\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -308,8 +317,12 @@ public class OnItemClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = target;\n"
         + "    unbinder.viewOriginal = view;\n"
@@ -319,10 +332,6 @@ public class OnItemClickTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -340,7 +349,8 @@ public class OnItemClickTest {
         + "      ((AdapterView<?>) viewOriginal).setOnItemClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnItemLongClickTest {
   @Test public void itemLongClick() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnItemLongClick;",
-        "public class Test extends Activity {",
-        "  @OnItemLongClick(1) boolean doStuff() { return false; }",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnItemLongClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnItemLongClick(1) boolean doStuff() { return false; }\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -35,8 +31,12 @@ public class OnItemLongClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -46,10 +46,6 @@ public class OnItemLongClickTest {
         + "        return target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -67,7 +63,8 @@ public class OnItemLongClickTest {
         + "      ((AdapterView<?>) view1).setOnItemLongClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
@@ -1,13 +1,9 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -15,14 +11,14 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 /** This augments {@link OnClickTest} with tests that exercise callbacks with multiple methods. */
 public class OnItemSelectedTest {
   @Test public void defaultMethod() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnItemSelected;",
-        "public class Test extends Activity {",
-        "  @OnItemSelected(1) void doStuff() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnItemSelected;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnItemSelected(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -36,8 +32,12 @@ public class OnItemSelectedTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -50,10 +50,6 @@ public class OnItemSelectedTest {
         + "      public void onNothingSelected(AdapterView<?> p0) {\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -71,7 +67,8 @@ public class OnItemSelectedTest {
         + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -81,16 +78,16 @@ public class OnItemSelectedTest {
   }
 
   @Test public void nonDefaultMethod() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnItemSelected;",
-        "import static butterknife.OnItemSelected.Callback.NOTHING_SELECTED;",
-        "public class Test extends Activity {",
-        "  @OnItemSelected(value = 1, callback = NOTHING_SELECTED)",
-        "  void doStuff() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;"
+        + "import android.app.Activity;"
+        + "import butterknife.OnItemSelected;"
+        + "import static butterknife.OnItemSelected.Callback.NOTHING_SELECTED;"
+        + "public class Test extends Activity {"
+        + "  @OnItemSelected(value = 1, callback = NOTHING_SELECTED)"
+        + "  void doStuff() {}"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -104,8 +101,12 @@ public class OnItemSelectedTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -118,10 +119,6 @@ public class OnItemSelectedTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -139,7 +136,8 @@ public class OnItemSelectedTest {
         + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -149,18 +147,18 @@ public class OnItemSelectedTest {
   }
 
   @Test public void allMethods() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnItemSelected;",
-        "import static butterknife.OnItemSelected.Callback.NOTHING_SELECTED;",
-        "public class Test extends Activity {",
-        "  @OnItemSelected(1)",
-        "  void onItemSelected() {}",
-        "  @OnItemSelected(value = 1, callback = NOTHING_SELECTED)",
-        "  void onNothingSelected() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;"
+        + "import android.app.Activity;"
+        + "import butterknife.OnItemSelected;"
+        + "import static butterknife.OnItemSelected.Callback.NOTHING_SELECTED;"
+        + "public class Test extends Activity {"
+        + "  @OnItemSelected(1)"
+        + "  void onItemSelected() {}"
+        + "  @OnItemSelected(value = 1, callback = NOTHING_SELECTED)"
+        + "  void onNothingSelected() {}"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -174,8 +172,12 @@ public class OnItemSelectedTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'onItemSelected' and method 'onNothingSelected'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -189,10 +191,6 @@ public class OnItemSelectedTest {
         + "        target.onNothingSelected();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -210,7 +208,8 @@ public class OnItemSelectedTest {
         + "      ((AdapterView<?>) view1).setOnItemSelectedListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -220,18 +219,18 @@ public class OnItemSelectedTest {
   }
 
   @Test public void multipleBindingPermutation() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnItemSelected;",
-        "import static butterknife.OnItemSelected.Callback.NOTHING_SELECTED;",
-        "public class Test extends Activity {",
-        "  @OnItemSelected({ 1, 2 })",
-        "  void onItemSelected() {}",
-        "  @OnItemSelected(value = { 1, 3 }, callback = NOTHING_SELECTED)",
-        "  void onNothingSelected() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;"
+        + "import android.app.Activity;"
+        + "import butterknife.OnItemSelected;"
+        + "import static butterknife.OnItemSelected.Callback.NOTHING_SELECTED;"
+        + "public class Test extends Activity {"
+        + "  @OnItemSelected({ 1, 2 })"
+        + "  void onItemSelected() {}"
+        + "  @OnItemSelected(value = { 1, 3 }, callback = NOTHING_SELECTED)"
+        + "  void onNothingSelected() {}"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -245,8 +244,12 @@ public class OnItemSelectedTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'onItemSelected' and method 'onNothingSelected'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -282,10 +285,6 @@ public class OnItemSelectedTest {
         + "        target.onNothingSelected();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -307,7 +306,8 @@ public class OnItemSelectedTest {
         + "      ((AdapterView<?>) view3).setOnItemSelectedListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
@@ -1,13 +1,9 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -15,15 +11,16 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 /** This augments {@link OnClickTest} with tests that exercise callbacks with return types. */
 public class OnLongClickTest {
   @Test public void onLongClickBinding() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnLongClick;",
-        "public class Test extends Activity {",
-        "  @OnLongClick(1) boolean doStuff() {",
-        "    return true;",
-        "  }",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnLongClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnLongClick(1) boolean doStuff() {\n"
+        + "    return true;\n"
+        + "  }\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -36,8 +33,12 @@ public class OnLongClickTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -47,10 +48,6 @@ public class OnLongClickTest {
         + "        return target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -68,7 +65,8 @@ public class OnLongClickTest {
         + "      view1.setOnLongClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -78,15 +76,16 @@ public class OnLongClickTest {
   }
 
   @Test public void failsIfMissingReturnType() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnLongClick;",
-        "public class Test extends Activity {",
-        "  @OnLongClick(1)",
-        "  public void doStuff() {",
-        "  }",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnLongClick;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnLongClick(1)\n"
+        + "  public void doStuff() {\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnPageChangeTest {
   @Test public void pageChange() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnPageChange;",
-        "public class Test extends Activity {",
-        "  @OnPageChange(1) void doStuff() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnPageChange;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnPageChange(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -35,8 +31,12 @@ public class OnPageChangeTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -52,10 +52,6 @@ public class OnPageChangeTest {
         + "      public void onPageScrollStateChanged(int p0) {\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -73,7 +69,8 @@ public class OnPageChangeTest {
         + "      ((ViewPager) view1).setOnPageChangeListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnTextChangedTest {
   @Test public void textChanged() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnTextChanged;",
-        "public class Test extends Activity {",
-        "  @OnTextChanged(1) void doStuff() {}",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnTextChanged;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnTextChanged(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -38,8 +34,12 @@ public class OnTextChangedTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -56,10 +56,6 @@ public class OnTextChangedTest {
         + "      }\n"
         + "    };\n"
         + "    ((TextView) view).addTextChangedListener(unbinder.view1TextWatcher);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -79,7 +75,8 @@ public class OnTextChangedTest {
         + "      view1TextWatcher = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
@@ -1,27 +1,23 @@
 package butterknife;
 
-import com.google.common.base.Joiner;
-import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
-import javax.tools.JavaFileObject;
-
 import butterknife.compiler.ButterKnifeProcessor;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class OnTouchTest {
   @Test public void touch() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnTouch;",
-        "public class Test extends Activity {",
-        "  @OnTouch(1) boolean doStuff() { return false; }",
-        "}"
-    ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnTouch;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnTouch(1) boolean doStuff() { return false; }\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -35,8 +31,12 @@ public class OnTouchTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -46,10 +46,6 @@ public class OnTouchTest {
         + "        return target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -67,7 +63,8 @@ public class OnTouchTest {
         + "      view1.setOnTouchListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -77,14 +74,15 @@ public class OnTouchTest {
   }
 
   @Test public void failsMultipleListenersWithReturnValue() throws Exception {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
-        "package test;",
-        "import android.app.Activity;",
-        "import butterknife.OnTouch;",
-        "public class Test extends Activity {",
-        "  @OnTouch(1) boolean doStuff1() {}",
-        "  @OnTouch(1) boolean doStuff2() {}",
-        "}"));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.app.Activity;\n"
+        + "import butterknife.OnTouch;\n"
+        + "public class Test extends Activity {\n"
+        + "  @OnTouch(1) boolean doStuff1() {}\n"
+        + "  @OnTouch(1) boolean doStuff2() {}\n"
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())

--- a/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
@@ -16,19 +16,15 @@ import static java.util.Arrays.asList;
 
 public class UnbinderTest {
   @Test public void bindingUnbinder() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
-        Joiner.on('\n')
-            .join(
-                "package test;",
-                "import android.support.v4.app.Fragment;",
-                "import butterknife.ButterKnife;",
-                "import butterknife.OnClick;",
-                "import butterknife.Unbinder;",
-                "public class Test extends Fragment {",
-                "  @OnClick(1) void doStuff() {",
-                "  }",
-                "}"
-            ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.support.v4.app.Fragment;\n"
+        + "import butterknife.ButterKnife;\n"
+        + "import butterknife.OnClick;\n"
+        + "import butterknife.Unbinder;\n"
+        + "public class Test extends Fragment {\n"
+        + "  @OnClick(1) void doStuff() {}\n"
+        + "}");
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -42,8 +38,12 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -53,10 +53,6 @@ public class UnbinderTest {
         + "        target.doStuff();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -74,7 +70,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -84,25 +81,22 @@ public class UnbinderTest {
   }
 
   @Test public void multipleBindings() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
-        Joiner.on('\n')
-            .join(
-                "package test;",
-                "import android.support.v4.app.Fragment;",
-                "import android.view.View;",
-                "import butterknife.BindView;",
-                "import butterknife.ButterKnife;",
-                "import butterknife.OnClick;",
-                "import butterknife.OnLongClick;",
-                "import butterknife.Unbinder;",
-                "public class Test extends Fragment {",
-                "  @BindView(1) View view;",
-                "  @BindView(2) View view2;",
-                "  @OnClick(1) void doStuff() {",
-                "  }",
-                "  @OnLongClick(1) boolean doMoreStuff() { return false; }",
-                "}"
-            ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.support.v4.app.Fragment;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.BindView;\n"
+        + "import butterknife.ButterKnife;\n"
+        + "import butterknife.OnClick;\n"
+        + "import butterknife.OnLongClick;\n"
+        + "import butterknife.Unbinder;\n"
+        + "public class Test extends Fragment {\n"
+        + "  @BindView(1) View view;\n"
+        + "  @BindView(2) View view2;\n"
+        + "  @OnClick(1) void doStuff() {}\n"
+        + "  @OnLongClick(1) boolean doMoreStuff() { return false; }\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -116,8 +110,12 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"field 'view', method 'doStuff', and method 'doMoreStuff'\");\n"
         + "    target.view = view;\n"
@@ -136,10 +134,6 @@ public class UnbinderTest {
         + "    });\n"
         + "    view = finder.findRequiredView(source, 2, \"field 'view2'\");\n"
         + "    target.view2 = view;\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -160,7 +154,8 @@ public class UnbinderTest {
         + "      target.view2 = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -170,20 +165,17 @@ public class UnbinderTest {
   }
 
   @Test public void unbinderRespectsNullable() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
-        Joiner.on('\n')
-            .join(
-                "package test;",
-                "import android.support.v4.app.Fragment;",
-                "import butterknife.ButterKnife;",
-                "import butterknife.OnClick;",
-                "import butterknife.Optional;",
-                "import butterknife.Unbinder;",
-                "public class Test extends Fragment {",
-                "  @Optional @OnClick(1) void doStuff() {",
-                "  }",
-                "}"
-            ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.support.v4.app.Fragment;\n"
+        + "import butterknife.ButterKnife;\n"
+        + "import butterknife.OnClick;\n"
+        + "import butterknife.Optional;\n"
+        + "import butterknife.Unbinder;\n"
+        + "public class Test extends Fragment {\n"
+        + "  @Optional @OnClick(1) void doStuff() {}\n"
+        + "}"
+    );
 
     JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -197,8 +189,12 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findOptionalView(source, 1, null);\n"
         + "    if (view != null) {\n"
@@ -210,10 +206,6 @@ public class UnbinderTest {
         + "        }\n"
         + "      });\n"
         + "    }\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -233,7 +225,8 @@ public class UnbinderTest {
         + "      }\n"
         + "    }\n"
         + "  }\n"
-        + "}");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -243,23 +236,20 @@ public class UnbinderTest {
   }
 
   @Test public void childBindsSecondUnbinder() {
-    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
-        Joiner.on('\n')
-            .join(
-                "package test;",
-                "import android.support.v4.app.Fragment;",
-                "import butterknife.ButterKnife;",
-                "import butterknife.OnClick;",
-                "import butterknife.Unbinder;",
-                "public class Test extends Fragment {",
-                "  @OnClick(1) void doStuff1() { }",
-                "}",
-                "class TestOne extends Test {",
-                "  @OnClick(1) void doStuff2() { }",
-                "}",
-                "class TestTwo extends Test {",
-                "}"
-            ));
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.support.v4.app.Fragment;\n"
+        + "import butterknife.ButterKnife;\n"
+        + "import butterknife.OnClick;\n"
+        + "import butterknife.Unbinder;\n"
+        + "public class Test extends Fragment {\n"
+        + "  @OnClick(1) void doStuff1() {}\n"
+        + "}\n"
+        + "class TestOne extends Test {\n"
+        + "  @OnClick(1) void doStuff2() {}\n"
+        + "}\n"
+        + "class TestTwo extends Test {}"
+    );
 
     JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
         + "package test;\n"
@@ -271,8 +261,13 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final TestOne target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    Test$$ViewBinder.bindToTarget(target, finder, source, unbinder);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -282,11 +277,6 @@ public class UnbinderTest {
         + "        target.doStuff2();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
         + "    View view1;\n"
@@ -299,7 +289,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
         + "package test;\n"
@@ -313,8 +304,12 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -324,10 +319,6 @@ public class UnbinderTest {
         + "        target.doStuff1();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -345,7 +336,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -381,8 +373,13 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final TestOne target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    Test$$ViewBinder.bindToTarget(target, finder, source, unbinder);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -392,11 +389,6 @@ public class UnbinderTest {
         + "        target.doStuff2();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
         + "    View view1;\n"
@@ -409,7 +401,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestOne$$ViewBinder", ""
         + "package test;\n"
@@ -423,8 +416,12 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -434,10 +431,6 @@ public class UnbinderTest {
         + "        target.doStuff1();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -455,7 +448,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -490,91 +484,93 @@ public class UnbinderTest {
             ));
 
     JavaFileObject expectedSource1 = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
-            + "package test;\n"
-            + "import android.view.View;\n"
-            + "import butterknife.Unbinder;\n"
-            + "import butterknife.internal.DebouncingOnClickListener;\n"
-            + "import butterknife.internal.Finder;\n"
-            + "import butterknife.internal.ViewBinder;\n"
-            + "import java.lang.IllegalStateException;\n"
-            + "import java.lang.Object;\n"
-            + "import java.lang.Override;\n"
-            + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
-            + "  @Override\n"
-            + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-            + "    InnerUnbinder unbinder = createUnbinder(target);\n"
-            + "    View view;\n"
-            + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
-            + "    unbinder.view1 = view;\n"
-            + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-            + "      @Override\n"
-            + "      public void doClick(View p0) {\n"
-            + "        target.doStuff1();\n"
-            + "      }\n"
-            + "    });\n"
-            + "    return unbinder;\n"
-            + "  }\n"
-            + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-            + "    return new InnerUnbinder(target);\n"
-            + "  }\n"
-            + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
-            + "    private T target;\n"
-            + "    View view1;\n"
-            + "    protected InnerUnbinder(T target) {\n"
-            + "      this.target = target;\n"
-            + "    }\n"
-            + "    @Override\n"
-            + "    public final void unbind() {\n"
-            + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
-            + "      unbind(target);\n"
-            + "      target = null;\n"
-            + "    }\n"
-            + "    protected void unbind(T target) {\n"
-            + "      view1.setOnClickListener(null);\n"
-            + "    }\n"
-            + "  }\n"
-            + "}");
+        + "package test;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.DebouncingOnClickListener;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.IllegalStateException;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    View view;\n"
+        + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
+        + "    unbinder.view1 = view;\n"
+        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
+        + "      @Override\n"
+        + "      public void doClick(View p0) {\n"
+        + "        target.doStuff1();\n"
+        + "      }\n"
+        + "    });\n"
+        + "  }\n"
+        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
+        + "    private T target;\n"
+        + "    View view1;\n"
+        + "    protected InnerUnbinder(T target) {\n"
+        + "      this.target = target;\n"
+        + "    }\n"
+        + "    @Override\n"
+        + "    public final void unbind() {\n"
+        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+        + "      unbind(target);\n"
+        + "      target = null;\n"
+        + "    }\n"
+        + "    protected void unbind(T target) {\n"
+        + "      view1.setOnClickListener(null);\n"
+        + "    }\n"
+        + "  }\n"
+        + "}"
+    );
 
-    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/one/TestOne$$ViewBinder", ""
-            + "package test.one;\n"
-            + "import android.view.View;\n"
-            + "import butterknife.Unbinder;\n"
-            + "import butterknife.internal.DebouncingOnClickListener;\n"
-            + "import butterknife.internal.Finder;\n"
-            + "import java.lang.Object;\n"
-            + "import java.lang.Override;\n"
-            + "import test.Test$$ViewBinder;\n"
-            + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
-            + "  @Override\n"
-            + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-            + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
-            + "    View view;\n"
-            + "    view = finder.findRequiredView(source, 2, \"method 'doStuff2'\");\n"
-            + "    unbinder.view2 = view;\n"
-            + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
-            + "      @Override\n"
-            + "      public void doClick(View p0) {\n"
-            + "        target.doStuff2();\n"
-            + "      }\n"
-            + "    });\n"
-            + "    return unbinder;\n"
-            + "  }\n"
-            + "  @Override\n"
-            + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-            + "    return new InnerUnbinder(target);\n"
-            + "  }\n"
-            + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
-            + "    View view2;\n"
-            + "    protected InnerUnbinder(T target) {\n"
-            + "      super(target);\n"
-            + "    }\n"
-            + "    @Override\n"
-            + "    protected void unbind(T target) {\n"
-            + "      super.unbind(target);\n"
-            + "      view2.setOnClickListener(null);\n"
-            + "    }\n"
-            + "  }\n"
-            + "}\n");
+    JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/one/TestOne$$ViewBinder", "package test.one;\n"
+        + "\n"
+        + "import android.view.View;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.DebouncingOnClickListener;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "import test.Test$$ViewBinder;\n"
+        + "public class TestOne$$ViewBinder<T extends TestOne> extends Test$$ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final TestOne target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    Test$$ViewBinder.bindToTarget(target, finder, source, unbinder);\n"
+        + "    View view;\n"
+        + "    view = finder.findRequiredView(source, 2, \"method 'doStuff2'\");\n"
+        + "    unbinder.view2 = view;\n"
+        + "    view.setOnClickListener(new DebouncingOnClickListener() {\n"
+        + "      @Override\n"
+        + "      public void doClick(View p0) {\n"
+        + "        target.doStuff2();\n"
+        + "      }\n"
+        + "    });\n"
+        + "  }\n"
+        + "  protected static class InnerUnbinder<T extends TestOne> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
+        + "    View view2;\n"
+        + "    protected InnerUnbinder(T target) {\n"
+        + "      super(target);\n"
+        + "    }\n"
+        + "    @Override\n"
+        + "    protected void unbind(T target) {\n"
+        + "      super.unbind(target);\n"
+        + "      view2.setOnClickListener(null);\n"
+        + "    }\n"
+        + "  }\n"
+        + "}"
+    );
 
     assertAbout(javaSources()).that(asList(source1, source2))
         .processedWith(new ButterKnifeProcessor())
@@ -614,8 +610,12 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final Test target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff1'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -625,10 +625,6 @@ public class UnbinderTest {
         + "        target.doStuff1();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
         + "    private T target;\n"
@@ -646,7 +642,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSource2 = JavaFileObjects.forSourceString("test/TestTwo$$ViewBinder", ""
         + "package test;\n"
@@ -658,8 +655,13 @@ public class UnbinderTest {
         + "import java.lang.Override;\n"
         + "public class TestTwo$$ViewBinder<T extends TestTwo> extends Test$$ViewBinder<T> {\n"
         + "  @Override\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
+        + "  protected static void bindToTarget(final TestTwo target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    Test$$ViewBinder.bindToTarget(target, finder, source, unbinder);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 1, \"method 'doStuff2'\");\n"
         + "    unbinder.view1 = view;\n"
@@ -669,11 +671,6 @@ public class UnbinderTest {
         + "        target.doStuff2();\n"
         + "      }\n"
         + "    });\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends TestTwo> extends Test$$ViewBinder.InnerUnbinder<T> {\n"
         + "    View view1;\n"
@@ -686,7 +683,8 @@ public class UnbinderTest {
         + "      view1.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     assertAbout(javaSource()).that(source)
         .processedWith(new ButterKnifeProcessor())
@@ -829,15 +827,19 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class A$$ViewBinder<T extends A> implements ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
+        + "  protected static void bindToTarget(final A target, Finder finder, Object source) {\n"
         + "    Context context = finder.getContext(source);\n"
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.blackColor = Utils.getColor(res, theme, 17170444);\n"
-        + "    return Unbinder.EMPTY;\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceB = JavaFileObjects.forSourceString("test/B$$ViewBinder", ""
         + "package test;\n"
@@ -851,16 +853,20 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class B$$ViewBinder<T extends B> extends A$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return Unbinder.EMPTY;\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
+        + "  protected static void bindToTarget(final B target, Finder finder, Object source) {\n"
+        + "    A$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    Context context = finder.getContext(source);\n"
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.whiteColor = Utils.getColor(res, theme, 17170443);\n"
-        + "    return unbinder;\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceC = JavaFileObjects.forSourceString("test/C$$ViewBinder", ""
         + "package test;\n"
@@ -876,10 +882,13 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class C$$ViewBinder<T extends C> extends B$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new InnerUnbinder(target);\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    super.bind(finder, target, source);\n"
-        + "    InnerUnbinder unbinder = createUnbinder(target);\n"
+        + "  protected static void bindToTarget(final C target, Finder finder, Object source) {\n"
+        + "    B$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 16908313, \"field 'button1'\");\n"
         + "    target.button1 = view;\n"
@@ -887,10 +896,6 @@ public class UnbinderTest {
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.transparentColor = Utils.getColor(res, theme, 17170445);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends C> implements Unbinder {\n"
         + "    private T target;\n"
@@ -907,7 +912,8 @@ public class UnbinderTest {
         + "      target.button1 = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceD = JavaFileObjects.forSourceString("test/D$$ViewBinder", ""
         + "package test;\n"
@@ -921,16 +927,20 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class D$$ViewBinder<T extends D> extends C$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new C$$ViewBinder.InnerUnbinder(target);\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
+        + "  protected static void bindToTarget(final D target, Finder finder, Object source) {\n"
+        + "    C$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    Context context = finder.getContext(source);\n"
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.grayColor = Utils.getColor(res, theme, 17170432);\n"
-        + "    return unbinder;\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceE = JavaFileObjects.forSourceString("test/E$$ViewBinder", ""
         + "package test;\n"
@@ -944,16 +954,20 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class E$$ViewBinder<T extends E> extends C$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new C$$ViewBinder.InnerUnbinder(target);\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
+        + "  protected static void bindToTarget(final E target, Finder finder, Object source) {\n"
+        + "    C$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    Context context = finder.getContext(source);\n"
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.backgroundDarkColor = Utils.getColor(res, theme, 17170446);\n"
-        + "    return unbinder;\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceF = JavaFileObjects.forSourceString("test/F$$ViewBinder", ""
         + "package test;\n"
@@ -967,16 +981,20 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class F$$ViewBinder<T extends F> extends D$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    bindToTarget(target, finder, source);\n"
+        + "    return new C$$ViewBinder.InnerUnbinder(target);\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    Unbinder unbinder = super.bind(finder, target, source);\n"
+        + "  protected static void bindToTarget(final F target, Finder finder, Object source) {\n"
+        + "    D$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    Context context = finder.getContext(source);\n"
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.backgroundLightColor = Utils.getColor(res, theme, 17170447);\n"
-        + "    return unbinder;\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceG = JavaFileObjects.forSourceString("test/G$$ViewBinder", ""
         + "package test;\n"
@@ -992,9 +1010,14 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class G$$ViewBinder<T extends G> extends E$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  protected static void bindToTarget(final G target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    E$$ViewBinder.bindToTarget(target, finder, source);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 16908314, \"field 'button2'\");\n"
         + "    target.button2 = view;\n"
@@ -1010,11 +1033,6 @@ public class UnbinderTest {
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.grayColor = Utils.getColor(res, theme, 17170432);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends G> extends C$$ViewBinder.InnerUnbinder<T> {\n"
         + "    View view16908290;\n"
@@ -1028,7 +1046,8 @@ public class UnbinderTest {
         + "      view16908290.setOnClickListener(null);\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     JavaFileObject expectedSourceH = JavaFileObjects.forSourceString("test/H$$ViewBinder", ""
         + "package test;\n"
@@ -1043,9 +1062,14 @@ public class UnbinderTest {
         + "import java.lang.SuppressWarnings;\n"
         + "public class H$$ViewBinder<T extends H> extends G$$ViewBinder<T> {\n"
         + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    InnerUnbinder unbinder = new InnerUnbinder(target);\n"
+        + "    bindToTarget(target, finder, source, unbinder);\n"
+        + "    return unbinder;\n"
+        + "  }\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
-        + "  public Unbinder bind(final Finder finder, final T target, Object source) {\n"
-        + "    InnerUnbinder unbinder = (InnerUnbinder) super.bind(finder, target, source);\n"
+        + "  protected static void bindToTarget(final H target, Finder finder, Object source, InnerUnbinder unbinder) {\n"
+        + "    G$$ViewBinder.bindToTarget(target, finder, source, unbinder);\n"
         + "    View view;\n"
         + "    view = finder.findRequiredView(source, 16908315, \"field 'button3'\");\n"
         + "    target.button3 = view;\n"
@@ -1053,11 +1077,6 @@ public class UnbinderTest {
         + "    Resources res = context.getResources();\n"
         + "    Resources.Theme theme = context.getTheme();\n"
         + "    target.grayColor = Utils.getColor(res, theme, 17170433);\n"
-        + "    return unbinder;\n"
-        + "  }\n"
-        + "  @Override\n"
-        + "  protected InnerUnbinder<T> createUnbinder(T target) {\n"
-        + "    return new InnerUnbinder(target);\n"
         + "  }\n"
         + "  protected static class InnerUnbinder<T extends H> extends G$$ViewBinder.InnerUnbinder<T> {\n"
         + "    protected InnerUnbinder(T target) {\n"
@@ -1069,7 +1088,8 @@ public class UnbinderTest {
         + "      target.button3 = null;\n"
         + "    }\n"
         + "  }\n"
-        + "}\n");
+        + "}"
+    );
 
     assertAbout(javaSources())
         .that(asList(sourceA,

--- a/butterknife-sample/src/main/java/com/example/butterknife/SimpleAdapter.java
+++ b/butterknife-sample/src/main/java/com/example/butterknife/SimpleAdapter.java
@@ -50,7 +50,7 @@ public class SimpleAdapter extends BaseAdapter {
     return view;
   }
 
-  static class ViewHolder {
+  static final class ViewHolder {
     @BindView(R.id.word) TextView word;
     @BindView(R.id.length) TextView length;
     @BindView(R.id.position) TextView position;

--- a/butterknife-sample/src/main/java/com/example/butterknife/unbinder/F.java
+++ b/butterknife-sample/src/main/java/com/example/butterknife/unbinder/F.java
@@ -6,7 +6,7 @@ import android.view.View;
 import butterknife.BindColor;
 import butterknife.ButterKnife;
 
-public class F extends D {
+public final class F extends D {
 
   @BindColor(android.R.color.background_light) @ColorInt int backgroundLightColor;
 


### PR DESCRIPTION
This switches each generated class to directly instantiate its unbinder (if needed, or the nearest parent's) and use static dispatch upward for binding views.