### PR TITLE
Clean up internals of how BindingClass generates code.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,6 @@ ext.deps = [
     // Square
     javapoet: 'com.squareup:javapoet:1.6.1',
 
-    // Other
-    rxjava: 'io.reactivex:rxjava:1.1.3',
-
     // Test dependencies
     junit: 'junit:junit:4.12',
     truth: 'com.google.truth:truth:0.28',

--- a/butterknife-compiler/build.gradle
+++ b/butterknife-compiler/build.gradle
@@ -17,7 +17,6 @@ dependencies {
   compile deps.autoservice
   compile deps.autocommon
   compile deps.javapoet
-  compile deps.rxjava
 
   testCompile deps.junit
   testCompile deps.truth


### PR DESCRIPTION
Remove the need to know about subclasses or parent types beyond the immediate. Type hierarchies are small so we can iterate them on-demand.