### PR TITLE
Update Robolectric to 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ ext.deps = [
     // Test dependencies
     junit: 'junit:junit:4.12',
     truth: 'com.google.truth:truth:0.28',
-    robolectric: 'org.robolectric:robolectric:2.2',
+    robolectric: 'org.robolectric:robolectric:3.1',
     compiletesting: 'com.google.testing.compile:compile-testing:0.9',
     autoservice: 'com.google.auto.service:auto-service:1.0-rc2',
     autocommon: 'com.google.auto:auto-common:0.6'

--- a/butterknife-compiler/build.gradle
+++ b/butterknife-compiler/build.gradle
@@ -21,6 +21,8 @@ dependencies {
   testCompile deps.junit
   testCompile deps.truth
   testCompile deps.robolectric
+  // TODO: Unfortunately we can't use deps.supportv4 here as the Java plugin does not support AAR dependencies
+  testCompile 'com.google.android:support-v4:r7'
   testCompile deps.compiletesting
   testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 }

--- a/butterknife-sample/src/test/java/com/example/butterknife/SimpleActivityTest.java
+++ b/butterknife-sample/src/test/java/com/example/butterknife/SimpleActivityTest.java
@@ -3,16 +3,14 @@ package com.example.butterknife;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.robolectric.RobolectricGradleTestRunner;
 
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(RobolectricTestRunner.class) //
-@Config(manifest = "src/main/AndroidManifest.xml")
+@RunWith(RobolectricGradleTestRunner.class)
 public class SimpleActivityTest {
   @Test public void verifyContentViewBinding() {
     SimpleActivity activity = Robolectric.buildActivity(SimpleActivity.class).create().get();

--- a/butterknife-sample/src/test/java/com/example/butterknife/SimpleAdapterTest.java
+++ b/butterknife-sample/src/test/java/com/example/butterknife/SimpleAdapterTest.java
@@ -3,20 +3,19 @@ package com.example.butterknife;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import static com.example.butterknife.SimpleAdapter.ViewHolder;
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(RobolectricTestRunner.class) //
-@Config(manifest = "src/main/AndroidManifest.xml")
+@RunWith(RobolectricGradleTestRunner.class)
 public class SimpleAdapterTest {
   @Test public void verifyViewHolderViews() {
-    Context context = Robolectric.application;
+    Context context = RuntimeEnvironment.application;
 
     View root = LayoutInflater.from(context).inflate(R.layout.simple_list_item, null);
     ViewHolder holder = new ViewHolder(root);

--- a/butterknife-sample/src/test/java/com/example/butterknife/unbinder/UnbinderTest.java
+++ b/butterknife-sample/src/test/java/com/example/butterknife/unbinder/UnbinderTest.java
@@ -6,32 +6,30 @@ import android.widget.FrameLayout;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(RobolectricTestRunner.class) //
-@Config(manifest = "src/main/AndroidManifest.xml")
+@RunWith(RobolectricGradleTestRunner.class)
 public final class UnbinderTest {
 
   @Test
   public void verifyContentViewBinding() {
-    FrameLayout frameLayout = new FrameLayout(Robolectric.application);
-    Button button1 = new Button(Robolectric.application);
+    FrameLayout frameLayout = new FrameLayout(RuntimeEnvironment.application);
+    Button button1 = new Button(RuntimeEnvironment.application);
     button1.setId(android.R.id.button1);
     frameLayout.addView(button1);
-    Button button2 = new Button(Robolectric.application);
+    Button button2 = new Button(RuntimeEnvironment.application);
     button2.setId(android.R.id.button2);
     frameLayout.addView(button2);
-    Button button3 = new Button(Robolectric.application);
+    Button button3 = new Button(RuntimeEnvironment.application);
     button3.setId(android.R.id.button3);
     frameLayout.addView(button3);
-    View content = new View(Robolectric.application);
+    View content = new View(RuntimeEnvironment.application);
     content.setId(android.R.id.content);
     frameLayout.addView(content);
     H h = new H(frameLayout);
@@ -53,5 +51,4 @@ public final class UnbinderTest {
     assertThat(h.button2).isNull();
     assertThat(h.button3).isNull();
   }
-
 }

--- a/butterknife-sample/src/test/resources/robolectric.properties
+++ b/butterknife-sample/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+constants=com.example.butterknife.BuildConfig
+sdk=21

--- a/butterknife/src/test/java/butterknife/ButterKnifeTest.java
+++ b/butterknife/src/test/java/butterknife/ButterKnifeTest.java
@@ -9,8 +9,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
@@ -54,7 +54,7 @@ public class ButterKnifeTest {
   }
 
   @Test public void propertyAppliedToView() {
-    View view = new View(Robolectric.application);
+    View view = new View(RuntimeEnvironment.application);
     assertThat(view.isEnabled()).isTrue();
 
     ButterKnife.apply(view, PROPERTY_ENABLED, false);
@@ -62,9 +62,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void propertyAppliedToEveryViewInList() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -78,9 +78,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void propertyAppliedToEveryViewInArray() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -94,7 +94,7 @@ public class ButterKnifeTest {
   }
 
   @Test public void actionAppliedToView() {
-    View view = new View(Robolectric.application);
+    View view = new View(RuntimeEnvironment.application);
     assertThat(view.isEnabled()).isTrue();
 
     ButterKnife.apply(view, ACTION_DISABLE);
@@ -103,7 +103,7 @@ public class ButterKnifeTest {
   }
 
   @Test public void actionsAppliedToView() {
-    View view = new View(Robolectric.application);
+    View view = new View(RuntimeEnvironment.application);
     assertThat(view.isEnabled()).isTrue();
     assertThat(view.getAlpha()).isEqualTo(1f);
 
@@ -113,9 +113,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void actionAppliedToEveryViewInList() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -129,9 +129,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void actionAppliedToEveryViewInArray() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -145,9 +145,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void actionsAppliedToEveryViewInList() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -167,9 +167,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void actionsAppliedToEveryViewInArray() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -189,7 +189,7 @@ public class ButterKnifeTest {
   }
 
   @Test public void setterAppliedToView() {
-    View view = new View(Robolectric.application);
+    View view = new View(RuntimeEnvironment.application);
     assertThat(view.isEnabled()).isTrue();
 
     ButterKnife.apply(view, SETTER_ENABLED, false);
@@ -198,9 +198,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void setterAppliedToEveryViewInList() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();
@@ -214,9 +214,9 @@ public class ButterKnifeTest {
   }
 
   @Test public void setterAppliedToEveryViewInArray() {
-    View view1 = new View(Robolectric.application);
-    View view2 = new View(Robolectric.application);
-    View view3 = new View(Robolectric.application);
+    View view1 = new View(RuntimeEnvironment.application);
+    View view2 = new View(RuntimeEnvironment.application);
+    View view3 = new View(RuntimeEnvironment.application);
     assertThat(view1.isEnabled()).isTrue();
     assertThat(view2.isEnabled()).isTrue();
     assertThat(view3.isEnabled()).isTrue();

--- a/butterknife/src/test/java/butterknife/internal/FinderTest.java
+++ b/butterknife/src/test/java/butterknife/internal/FinderTest.java
@@ -4,8 +4,8 @@ import android.view.View;
 import butterknife.shadow.EditModeShadowView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 @Config(manifest = Config.NONE)
 public final class FinderTest {
   @Test public void finderThrowsNiceError() {
-    View view = new View(Robolectric.application);
+    View view = new View(RuntimeEnvironment.application);
     try {
       Finder.VIEW.findRequiredView(view, android.R.id.button1, "yo mama");
       fail();
@@ -28,7 +28,7 @@ public final class FinderTest {
 
   @Config(shadows = EditModeShadowView.class)
   @Test public void finderThrowsLessNiceErrorInEditMode() {
-    View view = new View(Robolectric.application);
+    View view = new View(RuntimeEnvironment.application);
     try {
       Finder.VIEW.findRequiredView(view, android.R.id.button1, "yo mama");
       fail();


### PR DESCRIPTION
Robolectric 3.1 removes its transitive dependency on `com.google.android:support-v4:r7` so I had to include it manually. Unfortunately we can't use the `deps.supportv4` dependency as the Gradle Java plugin does not support AAR dependencies.