### PR TITLE
Allow using non-final IDs with @BindView.

### DIFF
--- a/butterknife-annotations/src/main/java/butterknife/BindView.java
+++ b/butterknife-annotations/src/main/java/butterknife/BindView.java
@@ -13,9 +13,28 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * <pre><code>
  * {@literal @}BindView(R.id.title) TextView title;
  * </code></pre>
+ *
+ * If used in a library project where the fields are not final, use the other attributes:
+ * <pre><code>
+ * {@literal @}BindView(idName = "title") TextView title;
+ * </code></pre>
  */
 @Retention(CLASS) @Target(FIELD)
 public @interface BindView {
-  /** View ID to which the field will be bound. */
-  @IdRes int value();
+  /** View ID to which the field will be bound. If used, this should be specified on it's own. */
+  @IdRes int value() default -1;
+
+  /**
+   * The name of the ID to use. For example, if the generated ID is referenced by
+   * {@code R.id.my_view} then this should be set to {@code "my_view"}.
+   *
+   * @see #idClass() to specify a generated resource class in a different package.
+   */
+  String idName() default "";
+
+  /**
+   * Generated {@code R.id} class which should be used with {@link #idName}. If not specified, it is
+   * assumed there is one available in the package this annotation is used in.
+   */
+  Class<?> idClass() default void.class;
 }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
@@ -45,7 +45,7 @@ final class BindingClass {
   private static final String UNBINDER_SIMPLE_NAME = "InnerUnbinder";
   private static final String BIND_TO_TARGET = "bindToTarget";
 
-  private final Map<Integer, ViewBindings> viewIdMap = new LinkedHashMap<>();
+  private final Map<Id, ViewBindings> viewIdMap = new LinkedHashMap<>();
   private final Map<FieldCollectionViewBinding, int[]> collectionBindings = new LinkedHashMap<>();
   private final List<FieldBitmapBinding> bitmapBindings = new ArrayList<>();
   private final List<FieldDrawableBinding> drawableBindings = new ArrayList<>();
@@ -71,7 +71,7 @@ final class BindingClass {
     drawableBindings.add(binding);
   }
 
-  void addField(int id, FieldViewBinding binding) {
+  void addField(Id id, FieldViewBinding binding) {
     getOrCreateViewBindings(id).setFieldBinding(binding);
   }
 
@@ -80,7 +80,7 @@ final class BindingClass {
   }
 
   boolean addMethod(
-      int id,
+      Id id,
       ListenerClass listener,
       ListenerMethod method,
       MethodViewBinding binding) {
@@ -100,11 +100,11 @@ final class BindingClass {
     this.parentBinding = parent;
   }
 
-  ViewBindings getViewBinding(int id) {
+  ViewBindings getViewBinding(Id id) {
     return viewIdMap.get(id);
   }
 
-  private ViewBindings getOrCreateViewBindings(int id) {
+  private ViewBindings getOrCreateViewBindings(Id id) {
     ViewBindings viewId = viewIdMap.get(id);
     if (viewId == null) {
       viewId = new ViewBindings(id);

--- a/butterknife-compiler/src/main/java/butterknife/compiler/Id.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/Id.java
@@ -1,0 +1,85 @@
+package butterknife.compiler;
+
+import com.squareup.javapoet.ClassName;
+import java.util.Objects;
+
+/**
+ * Represents an ID of an Android resource.
+ */
+interface Id {
+
+  /**
+   * A final ID.
+   */
+  final class Constant implements Id {
+
+    private final int id;
+
+    Constant(int id) {
+      this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Constant constant = (Constant) o;
+      return id == constant.id;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(id);
+    }
+
+    public int getId() {
+      return id;
+    }
+  }
+
+  /**
+   * A non-final ID (produced by library projects).
+   */
+  final class Reference implements Id {
+
+    private final ClassName idClassName;
+    private final String idName;
+
+    Reference(ClassName idClassName, String idName) {
+      this.idClassName = idClassName;
+      this.idName = idName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Reference reference = (Reference) o;
+      return Objects.equals(idClassName, reference.idClassName)
+          && Objects.equals(idName, reference.idName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(idClassName, idName);
+    }
+
+    @Override
+    public String toString() {
+      return idClassName + "." + idName;
+    }
+  }
+}

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ViewBindings.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ViewBindings.java
@@ -10,16 +10,16 @@ import java.util.Map;
 import java.util.Set;
 
 final class ViewBindings {
-  private final int id;
+  private final Id id;
   private final LinkedHashMap<ListenerClass, Map<ListenerMethod, Set<MethodViewBinding>>>
       methodBindings = new LinkedHashMap<>();
   private FieldViewBinding fieldBinding;
 
-  ViewBindings(int id) {
+  ViewBindings(Id id) {
     this.id = id;
   }
 
-  public int getId() {
+  public Id getId() {
     return id;
   }
 
@@ -92,6 +92,6 @@ final class ViewBindings {
   }
 
   public boolean isBoundToRoot() {
-    return id == ButterKnifeProcessor.NO_ID;
+    return id instanceof Id.Constant && ((Id.Constant) id).getId() == ButterKnifeProcessor.NO_ID;
   }
 }

--- a/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
@@ -61,6 +61,104 @@ public class BindViewTest {
         .generatesSources(expectedSource);
   }
 
+  @Test public void bindingViewIdName() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n').join(
+            "package butterknife;",
+            "import android.app.Activity;",
+            "import android.view.View;",
+            "import butterknife.BindView;",
+            "public class Test extends Activity {",
+            "    @BindView(idName = \"my_view\") View thing;",
+            "}"
+        ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package butterknife;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.IllegalStateException;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    return new InnerUnbinder<>(target, finder, source);\n"
+        + "  }\n"
+        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
+        + "    protected T target;\n"
+        + "    protected InnerUnbinder(T target, Finder finder, Object source) {\n"
+        + "      this.target = target;\n"
+        + "      target.thing = finder.findRequiredView(source, butterknife.R.id.my_view, \"field 'thing'\");\n"
+        + "    }\n"
+        + "    @Override\n"
+        + "    public void unbind() {\n"
+        + "      T target = this.target;\n"
+        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+        + "      target.thing = null;\n"
+        + "      this.target = null;\n"
+        + "    }\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void bindingViewIdNameAndClass() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
+        Joiner.on('\n').join(
+            "package test;",
+            "import android.app.Activity;",
+            "import android.view.View;",
+            "import butterknife.BindView;",
+            "import butterknife.R;",
+            "public class Test extends Activity {",
+            "    @BindView(idClass = R.id.class, idName = \"my_view\") View thing;",
+            "}"
+        ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/Test$$ViewBinder", ""
+        + "package test;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Finder;\n"
+        + "import butterknife.internal.ViewBinder;\n"
+        + "import java.lang.IllegalStateException;\n"
+        + "import java.lang.Object;\n"
+        + "import java.lang.Override;\n"
+        + "public class Test$$ViewBinder<T extends Test> implements ViewBinder<T> {\n"
+        + "  @Override\n"
+        + "  public Unbinder bind(Finder finder, T target, Object source) {\n"
+        + "    return new InnerUnbinder<>(target, finder, source);\n"
+        + "  }\n"
+        + "  protected static class InnerUnbinder<T extends Test> implements Unbinder {\n"
+        + "    protected T target;\n"
+        + "    protected InnerUnbinder(T target, Finder finder, Object source) {\n"
+        + "      this.target = target;\n"
+        + "      target.thing = finder.findRequiredView(source, butterknife.R.id.my_view, \"field 'thing'\");\n"
+        + "    }\n"
+        + "    @Override\n"
+        + "    public void unbind() {\n"
+        + "      T target = this.target;\n"
+        + "      if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+        + "      target.thing = null;\n"
+        + "      this.target = null;\n"
+        + "    }\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
   @Test public void bindingViewFinalClass() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test",
         Joiner.on('\n').join(

--- a/butterknife-compiler/src/test/java/butterknife/R.java
+++ b/butterknife-compiler/src/test/java/butterknife/R.java
@@ -1,0 +1,10 @@
+package butterknife;
+
+/**
+ * Class designed to look like a resources class produced by an Android library project.
+ */
+public final class R {
+  public static final class id {
+    public static int my_view = 1;
+  }
+}


### PR DESCRIPTION
Implementation of allowing use of non-final resource IDs produced by Android library projects. Backwards compatible with the current method (and I would say it should remain the best practice for non-library projects).

In #2, you say you don't want to support this case unless someone puts forward a good use case. At Google, we have our own build system which we use for (almost) every project (open sourced as Bazel http://bazel.io). Part of the best-practices for using this build system is to have a separate library for each Java package. This means every Java package in an Android app built using this tool at Google is a separate Android library. We also put package-relevant resources with the package, i.e. each package has its own res/ directory. This means all of our resources are part of Android libraries and hence none of the IDs are final. So this is a requirement for any Google app to use Butter Knife.

This pull request only fixes the problem for BindView, but it should be possible to apply a similar pattern to other bindings. One design question I came across was whether it would make sense to create a new annotation, say `@Id` and then have `@BindView(id = @Id("my_view"))` or `@BindView(id = @Id("my_view", res = other.package.R.id.class))`. I think `@Id` might be easier to extend to other bindings but potentially too boilerplatey.

Please take a look and let me know what you think.