### PR TITLE
Fix unescaped File.separator on Windows environment (butterknife-gradle-plugin).

### DIFF
--- a/butterknife-gradle-plugin/src/main/groovy/butterknife/plugin/ButterKnifePlugin.groovy
+++ b/butterknife-gradle-plugin/src/main/groovy/butterknife/plugin/ButterKnifePlugin.groovy
@@ -5,6 +5,7 @@ import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.TestPlugin
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
+import groovy.json.StringEscapeUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -27,7 +28,8 @@ public class ButterKnifePlugin implements Plugin<Project> {
       variants.all { BaseVariant variant ->
         variant.outputs.each { BaseVariantOutput output ->
           output.processResources.doLast {
-            File rDir = new File(sourceOutputDir, packageForR.replaceAll('\\.', File.separator))
+            File rDir = new File(sourceOutputDir, packageForR.replaceAll('\\.',
+                    StringEscapeUtils.escapeJava(File.separator)))
             File R = new File(rDir, 'R.java')
             FinalRClassBuilder.brewJava(R, sourceOutputDir, packageForR, 'R2')
           }


### PR DESCRIPTION
On _Windows environment_ the following statement throws an exception:
```javascript
packageForR.replaceAll('\\.', File.separator)
```

``` 
Caused by: java.lang.IllegalArgumentException: character to be escaped is missing
	at java_lang_String$replaceAll$8.call(Unknown Source)
	at butterknife.plugin.ButterKnifePlugin$_apply_closure1$_closure2$_closure3$_closure4.doCall(ButterKnifePlugin.groovy:30)
	at org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:554)
	at org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:535)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:80)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:61)
	... 70 more
```

After the proper escape of the `\\` file separator, the _butterknife-gradle-plugin_ can run without any errors.