### PR TITLE
Change & reuse Finder.castView(…)

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
@@ -535,8 +535,9 @@ final class BindingClass {
     FieldViewBinding fieldBinding = bindings.getFieldBinding();
     if (fieldBinding != null) {
       if (requiresCast(fieldBinding.getType())) {
-        result.addStatement("target.$L = finder.castView(view, $L, $S)", fieldBinding.getName(),
-            bindings.getId().code, asHumanDescription(singletonList(fieldBinding)));
+        result.addStatement("target.$L = finder.castView(view, $L, $S, $T.class)",
+            fieldBinding.getName(), bindings.getId().code,
+            asHumanDescription(singletonList(fieldBinding)), fieldBinding.getRawType());
       } else {
         result.addStatement("target.$L = view", fieldBinding.getName());
       }

--- a/butterknife-compiler/src/test/java/butterknife/internal/Finder.java
+++ b/butterknife-compiler/src/test/java/butterknife/internal/Finder.java
@@ -21,7 +21,7 @@ public class Finder {
     throw new RuntimeException("Stub!");
   }
 
-  public <T> T castView(View view, int id, String who) {
+  public <T> T castView(View view, int id, String who, Class<T> cls) {
     throw new RuntimeException("Stub!");
   }
 

--- a/butterknife/src/main/java/butterknife/internal/Finder.java
+++ b/butterknife/src/main/java/butterknife/internal/Finder.java
@@ -48,18 +48,7 @@ public enum Finder {
 
   public final <T> T findOptionalViewAsType(Object source, int id, String who, Class<T> cls) {
     View view = findOptionalView(source, id);
-    try {
-      return cls.cast(view);
-    } catch (ClassCastException e) {
-      String name = getResourceEntryName(view, id);
-      throw new IllegalStateException("View '"
-          + name
-          + "' with ID "
-          + id
-          + " for "
-          + who
-          + " was of the wrong type. See cause for more info.", e);
-    }
+    return castView(view, id, who, cls);
   }
 
   public final View findRequiredView(Object source, int id, String who) {
@@ -80,24 +69,12 @@ public enum Finder {
 
   public final <T> T findRequiredViewAsType(Object source, int id, String who, Class<T> cls) {
     View view = findRequiredView(source, id, who);
-    try {
-      return cls.cast(view);
-    } catch (ClassCastException e) {
-      String name = getResourceEntryName(view, id);
-      throw new IllegalStateException("View '"
-          + name
-          + "' with ID "
-          + id
-          + " for "
-          + who
-          + " was of the wrong type. See cause for more info.", e);
-    }
+    return castView(view, id, who, cls);
   }
 
-  @SuppressWarnings("unchecked") // That's the point.
-  public final <T> T castView(View view, int id, String who) {
+  public final <T> T castView(View view, int id, String who, Class<T> cls) {
     try {
-      return (T) view;
+      return cls.cast(view);
     } catch (ClassCastException e) {
       String name = getResourceEntryName(view, id);
       throw new IllegalStateException("View '"


### PR DESCRIPTION
Follow-up to #655.

Change `Finder.castView` to expect `Class<T>` as argument and use `cls.cast(view)` instead of `(T) view`. This code path was also untested previously, so I added a simple test for this case.

Finally change `findOptionalViewAsType` and `findRequiredViewAsType` to re-use this method.