### PR TITLE
Guard for null tree when scanning for R Classes

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -1162,7 +1162,9 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     for (Class<? extends Annotation> annotation : getSupportedAnnotations()) {
       for (Element element : env.getElementsAnnotatedWith(annotation)) {
         JCTree tree = (JCTree) trees.getTree(element, getMirror(element, annotation));
-        tree.accept(scanner);
+        if (tree != null) { // tree can be null if the references are compiled types and not source
+          tree.accept(scanner);
+        }
       }
     }
 


### PR DESCRIPTION
This guards against #670 in which case butterknife falls back to legacy behavior of using hardcoded constants in generated code instead of `R` references.