### PR TITLE
Add @UiThread to generated class constructors.

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingClass.java
@@ -35,6 +35,8 @@ final class BindingClass {
   private static final ClassName CONTEXT = ClassName.get("android.content", "Context");
   private static final ClassName RESOURCES = ClassName.get("android.content.res", "Resources");
   private static final ClassName THEME = RESOURCES.nestedClass("Theme");
+  private static final ClassName UI_THREAD =
+      ClassName.get("android.support.annotation", "UiThread");
   private static final ClassName UNBINDER = ClassName.get("butterknife", "Unbinder");
   private static final ClassName BITMAP_FACTORY =
       ClassName.get("android.graphics", "BitmapFactory");
@@ -151,6 +153,7 @@ final class BindingClass {
                 + "Only present for runtime invocation through {@code ButterKnife.bind()}.\n",
             bindingClassName, targetType, CONTEXT)
         .addAnnotation(Deprecated.class)
+        .addAnnotation(UI_THREAD)
         .addModifiers(PUBLIC)
         .addParameter(targetType, "target")
         .addParameter(VIEW, "source")
@@ -160,6 +163,7 @@ final class BindingClass {
 
   private MethodSpec createBindingConstructor(TypeName targetType) {
     MethodSpec.Builder constructor = MethodSpec.constructorBuilder()
+        .addAnnotation(UI_THREAD)
         .addModifiers(PUBLIC);
 
     if (hasMethodBindings()) {

--- a/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindArrayTest.java
@@ -24,6 +24,7 @@ public class BindArrayTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -37,9 +38,11 @@ public class BindArrayTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -56,6 +59,7 @@ public class BindArrayTest {
 
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -77,6 +81,7 @@ public class BindArrayTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -90,9 +95,11 @@ public class BindArrayTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -108,6 +115,7 @@ public class BindArrayTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -129,6 +137,7 @@ public class BindArrayTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -142,9 +151,11 @@ public class BindArrayTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -160,6 +171,7 @@ public class BindArrayTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -182,6 +194,7 @@ public class BindArrayTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -195,9 +208,11 @@ public class BindArrayTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -213,6 +228,7 @@ public class BindArrayTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindBitmapTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindBitmapTest.java
@@ -26,6 +26,7 @@ public class BindBitmapTest {
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
         + "import android.graphics.BitmapFactory;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -39,9 +40,11 @@ public class BindBitmapTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -57,6 +60,7 @@ public class BindBitmapTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindBoolTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindBoolTest.java
@@ -24,6 +24,7 @@ public class BindBoolTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -37,9 +38,11 @@ public class BindBoolTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -55,6 +58,7 @@ public class BindBoolTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindColorTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindColorTest.java
@@ -24,6 +24,7 @@ public class BindColorTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -38,9 +39,11 @@ public class BindColorTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -57,6 +60,7 @@ public class BindColorTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -79,6 +83,7 @@ public class BindColorTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -93,9 +98,11 @@ public class BindColorTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -112,6 +119,7 @@ public class BindColorTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindDimenTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindDimenTest.java
@@ -24,6 +24,7 @@ public class BindDimenTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -37,9 +38,11 @@ public class BindDimenTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -55,6 +58,7 @@ public class BindDimenTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -76,6 +80,7 @@ public class BindDimenTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -89,9 +94,11 @@ public class BindDimenTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -107,6 +114,7 @@ public class BindDimenTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindDrawableTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindDrawableTest.java
@@ -25,6 +25,7 @@ public class BindDrawableTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -39,9 +40,11 @@ public class BindDrawableTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -58,6 +61,7 @@ public class BindDrawableTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -80,6 +84,7 @@ public class BindDrawableTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -94,9 +99,11 @@ public class BindDrawableTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -113,6 +120,7 @@ public class BindDrawableTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindFloatTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindFloatTest.java
@@ -24,6 +24,7 @@ public class BindFloatTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -38,9 +39,11 @@ public class BindFloatTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -56,6 +59,7 @@ public class BindFloatTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindIntTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindIntTest.java
@@ -24,6 +24,7 @@ public class BindIntTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -37,9 +38,11 @@ public class BindIntTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -55,6 +58,7 @@ public class BindIntTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindStringTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindStringTest.java
@@ -24,6 +24,7 @@ public class BindStringTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -37,9 +38,11 @@ public class BindStringTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  @SuppressWarnings(\"ResourceType\")\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
@@ -55,6 +58,7 @@ public class BindStringTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewTest.java
@@ -26,6 +26,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -33,6 +34,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -48,6 +50,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -103,6 +106,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -110,6 +114,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public final class Test_ViewBinding implements Unbinder {\n"
         + "  private Test target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(Test target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -125,6 +130,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -152,6 +158,7 @@ public class BindViewTest {
 
     JavaFileObject bindingBaseSource = JavaFileObjects.forSourceString("test/Base_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -159,6 +166,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Base_ViewBinding<T extends Base> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Base_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -175,10 +183,12 @@ public class BindViewTest {
 
     JavaFileObject bindingTestSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public final class Test_ViewBinding extends Base_ViewBinding<Test> {\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(Test target, View source) {\n"
         + "    super(target, source);\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -193,6 +203,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSources()).that(asList(baseSource, testSource))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -214,6 +225,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Outer$Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -221,6 +233,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Outer$Test_ViewBinding<T extends Outer.Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Outer$Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -236,6 +249,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -255,6 +269,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package com.Example;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -262,6 +277,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -277,6 +293,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -297,6 +314,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -304,6 +322,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredViewAsType(source, 1, \"field 'thing'\", Test.TestInterface.class);\n"
@@ -319,6 +338,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -339,6 +359,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.TextView;\n"
         + "import butterknife.Unbinder;\n"
@@ -347,6 +368,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.findRequiredViewAsType(source, 1, \"field 'thing'\", TextView.class);\n"
@@ -362,6 +384,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         // found raw type: test.Test
         //   missing type arguments for generic class test.Test<T>
@@ -385,6 +408,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -394,6 +418,7 @@ public class BindViewTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -420,6 +445,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -441,6 +467,7 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.Button;\n"
         + "import butterknife.Unbinder;\n"
@@ -451,6 +478,7 @@ public class BindViewTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -477,6 +505,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutError()
         .and()
@@ -497,6 +526,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings();
   }
@@ -515,12 +545,14 @@ public class BindViewTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.IllegalStateException;\n"
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.view = source.findViewById(1);\n"
@@ -571,6 +603,7 @@ public class BindViewTest {
 
     JavaFileObject binding1Source = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -578,6 +611,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.view = Utils.findRequiredView(source, 1, \"field 'view'\");\n"
@@ -594,10 +628,12 @@ public class BindViewTest {
 
     JavaFileObject binding2Source = JavaFileObjects.forSourceString("test/TestOne_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class TestOne_ViewBinding<T extends TestOne> extends Test_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public TestOne_ViewBinding(T target, View source) {\n"
         + "    super(target, source);\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -612,6 +648,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSources()).that(asList(source1, source2, source3))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -646,6 +683,7 @@ public class BindViewTest {
 
     JavaFileObject binding1Source = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -653,6 +691,7 @@ public class BindViewTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.view = Utils.findRequiredView(source, 1, \"field 'view'\");\n"
@@ -669,10 +708,12 @@ public class BindViewTest {
 
     JavaFileObject binding2Source = JavaFileObjects.forSourceString("test/TestOne_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class TestOne_ViewBinding<T extends TestOne> extends Test_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public TestOne_ViewBinding(T target, View source) {\n"
         + "    super(target, source);\n"
         + "    target.thing = Utils.findRequiredView(source, 1, \"field 'thing'\");\n"
@@ -687,6 +728,7 @@ public class BindViewTest {
     );
 
     assertAbout(javaSources()).that(asList(source1, source2, source3))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         // found raw type: test.Test
         //   missing type arguments for generic class test.Test<T>

--- a/butterknife-compiler/src/test/java/butterknife/BindViewsTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/BindViewsTest.java
@@ -28,6 +28,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings();
   }
@@ -45,6 +46,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -52,6 +54,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.arrayOf(\n"
@@ -70,6 +73,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -89,6 +93,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -96,6 +101,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.arrayOf(\n"
@@ -114,6 +120,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         // found raw type: test.Test
         //   missing type arguments for generic class test.Test<T>
@@ -135,6 +142,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.TextView;\n"
         + "import butterknife.Unbinder;\n"
@@ -143,6 +151,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.arrayOf(\n"
@@ -161,6 +170,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -181,6 +191,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -188,6 +199,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.listOf(\n"
@@ -206,6 +218,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -264,6 +277,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -271,6 +285,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.listOf(\n"
@@ -289,6 +304,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -309,6 +325,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -316,6 +333,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.listOf(\n"
@@ -334,6 +352,7 @@ public class BindViewsTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         // found raw type: test.Test
         //   missing type arguments for generic class test.Test<T>
@@ -357,6 +376,7 @@ public class BindViewsTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -364,6 +384,7 @@ public class BindViewsTest {
         + "import java.lang.Override;\n"
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this.target = target;\n"
         + "    target.thing = Utils.listOf(\n"

--- a/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnCheckedChangedTest.java
@@ -21,6 +21,7 @@ public class OnCheckedChangedTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.CompoundButton;\n"
         + "import butterknife.Unbinder;\n"
@@ -30,6 +31,7 @@ public class OnCheckedChangedTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -53,6 +55,7 @@ public class OnCheckedChangedTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnClickTest.java
@@ -21,6 +21,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -30,6 +31,7 @@ public class OnClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -53,6 +55,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -71,6 +74,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -80,6 +84,7 @@ public class OnClickTest {
         + "public final class Test_ViewBinding implements Unbinder {\n"
         + "  private Test target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final Test target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -103,6 +108,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -124,6 +130,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -134,6 +141,7 @@ public class OnClickTest {
         + "  protected T target;\n"
         + "  private View view1;\n"
         + "  private View view2;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -169,6 +177,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -190,6 +199,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -199,6 +209,7 @@ public class OnClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -225,6 +236,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -245,6 +257,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings();
   }
@@ -269,6 +282,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.Button;\n"
         + "import android.widget.TextView;\n"
@@ -284,6 +298,7 @@ public class OnClickTest {
         + "  private View view2;\n"
         + "  private View view3;\n"
         + "  private View view4;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -347,6 +362,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -366,6 +382,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -377,6 +394,7 @@ public class OnClickTest {
         + "  private View view1;\n"
         + "  private View view2;\n"
         + "  private View view3;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -420,6 +438,7 @@ public class OnClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -438,6 +457,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -446,6 +466,7 @@ public class OnClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -496,6 +517,7 @@ public class OnClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -505,6 +527,7 @@ public class OnClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"

--- a/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnEditorActionTest.java
@@ -21,6 +21,7 @@ public class OnEditorActionTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.KeyEvent;\n"
         + "import android.view.View;\n"
         + "import android.widget.TextView;\n"
@@ -31,6 +32,7 @@ public class OnEditorActionTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -54,6 +56,7 @@ public class OnEditorActionTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnFocusChangeTest.java
@@ -21,6 +21,7 @@ public class OnFocusChangeTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -29,6 +30,7 @@ public class OnFocusChangeTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -52,6 +54,7 @@ public class OnFocusChangeTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemClickTest.java
@@ -22,6 +22,7 @@ public class OnItemClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -31,6 +32,7 @@ public class OnItemClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -54,6 +56,7 @@ public class OnItemClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -79,6 +82,7 @@ public class OnItemClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -88,6 +92,7 @@ public class OnItemClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -111,6 +116,7 @@ public class OnItemClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -134,6 +140,7 @@ public class OnItemClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import android.widget.ListView;\n"
@@ -144,6 +151,7 @@ public class OnItemClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -167,6 +175,7 @@ public class OnItemClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -190,6 +199,7 @@ public class OnItemClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import android.widget.ListView;\n"
@@ -200,6 +210,7 @@ public class OnItemClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -224,6 +235,7 @@ public class OnItemClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         // found raw type: test.Test
         //   missing type arguments for generic class test.Test<T>
@@ -248,6 +260,7 @@ public class OnItemClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -256,6 +269,7 @@ public class OnItemClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View viewSource;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    viewSource = source;\n"
@@ -277,6 +291,7 @@ public class OnItemClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -294,6 +309,7 @@ public class OnItemClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -302,6 +318,7 @@ public class OnItemClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View viewSource;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    viewSource = source;\n"
@@ -323,6 +340,7 @@ public class OnItemClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemLongClickTest.java
@@ -21,6 +21,7 @@ public class OnItemLongClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -30,6 +31,7 @@ public class OnItemLongClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -53,6 +55,7 @@ public class OnItemLongClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnItemSelectedTest.java
@@ -22,7 +22,7 @@ public class OnItemSelectedTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
-        + "\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -32,6 +32,7 @@ public class OnItemSelectedTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -58,6 +59,7 @@ public class OnItemSelectedTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -78,6 +80,7 @@ public class OnItemSelectedTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -87,6 +90,7 @@ public class OnItemSelectedTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -113,6 +117,7 @@ public class OnItemSelectedTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -135,6 +140,7 @@ public class OnItemSelectedTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -144,6 +150,7 @@ public class OnItemSelectedTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -171,6 +178,7 @@ public class OnItemSelectedTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -193,6 +201,7 @@ public class OnItemSelectedTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import android.widget.AdapterView;\n"
         + "import butterknife.Unbinder;\n"
@@ -204,6 +213,7 @@ public class OnItemSelectedTest {
         + "  private View view1;\n"
         + "  private View view2;\n"
         + "  private View view3;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -257,6 +267,7 @@ public class OnItemSelectedTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnLongClickTest.java
@@ -24,6 +24,7 @@ public class OnLongClickTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -32,7 +33,8 @@ public class OnLongClickTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
-        + "  public  Test_ViewBinding(final T target, View source) {\n"
+        + "  @UiThread\n"
+        + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
         + "    view = Utils.findRequiredView(source, 1, \"method 'doStuff'\");\n"
@@ -55,6 +57,7 @@ public class OnLongClickTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnPageChangeTest.java
@@ -21,6 +21,7 @@ public class OnPageChangeTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.support.v4.view.ViewPager;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
@@ -31,6 +32,7 @@ public class OnPageChangeTest {
         + "  protected T target;\n"
         + "  private View view1;\n"
         + "  private ViewPager.OnPageChangeListener view1OnPageChangeListener;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -62,6 +64,7 @@ public class OnPageChangeTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTextChangedTest.java
@@ -21,6 +21,7 @@ public class OnTextChangedTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.text.Editable;\n"
         + "import android.text.TextWatcher;\n"
         + "import android.view.View;\n"
@@ -34,6 +35,7 @@ public class OnTextChangedTest {
         + "  protected T target;\n"
         + "  private View view1;\n"
         + "  private TextWatcher view1TextWatcher;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -65,6 +67,7 @@ public class OnTextChangedTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/OnTouchTest.java
@@ -21,6 +21,7 @@ public class OnTouchTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.MotionEvent;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
@@ -30,6 +31,7 @@ public class OnTouchTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -53,6 +55,7 @@ public class OnTouchTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/RClassTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/RClassTest.java
@@ -92,6 +92,7 @@ public class RClassTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -104,9 +105,11 @@ public class RClassTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
         + "    Resources res = context.getResources();\n"
@@ -121,6 +124,7 @@ public class RClassTest {
     );
 
     assertAbout(javaSources()).that(asList(source, NON_FINAL_R, R2))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -142,6 +146,7 @@ public class RClassTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import java.lang.Deprecated;\n"
@@ -154,9 +159,11 @@ public class RClassTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
         + "    Resources res = context.getResources();\n"
@@ -171,6 +178,7 @@ public class RClassTest {
     );
 
     assertAbout(javaSources()).that(asList(source, FINAL_R))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -192,6 +200,7 @@ public class RClassTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -205,9 +214,11 @@ public class RClassTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
         + "    Resources res = context.getResources();\n"
@@ -223,6 +234,7 @@ public class RClassTest {
     );
 
     assertAbout(javaSources()).that(asList(source, NON_FINAL_R))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()

--- a/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
+++ b/butterknife-compiler/src/test/java/butterknife/UnbinderTest.java
@@ -29,6 +29,7 @@ public class UnbinderTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -38,6 +39,7 @@ public class UnbinderTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -73,6 +75,7 @@ public class UnbinderTest {
     );
 
     assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -92,6 +95,7 @@ public class UnbinderTest {
 
     JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -100,6 +104,7 @@ public class UnbinderTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -159,6 +164,7 @@ public class UnbinderTest {
 
     JavaFileObject binding1Source = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -168,6 +174,7 @@ public class UnbinderTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -192,12 +199,14 @@ public class UnbinderTest {
 
     JavaFileObject binding2Source = JavaFileObjects.forSourceString("test/TestOne_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class TestOne_ViewBinding<T extends TestOne> extends Test_ViewBinding<T> {\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public TestOne_ViewBinding(final T target, View source) {\n"
         + "    super(target, source);\n"
         + "    View view;\n"
@@ -220,6 +229,7 @@ public class UnbinderTest {
     );
 
     assertAbout(javaSources()).that(asList(source1, source2, source3))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -246,6 +256,7 @@ public class UnbinderTest {
 
     JavaFileObject binding1Source = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -255,6 +266,7 @@ public class UnbinderTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -279,12 +291,14 @@ public class UnbinderTest {
 
     JavaFileObject binding2Source = JavaFileObjects.forSourceString("test/TestOne_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class TestOne_ViewBinding<T extends TestOne> extends Test_ViewBinding<T> {\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public TestOne_ViewBinding(final T target, View source) {\n"
         + "    super(target, source);\n"
         + "    View view;\n"
@@ -307,6 +321,7 @@ public class UnbinderTest {
     );
 
     assertAbout(javaSources()).that(asList(source1, source2))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -334,6 +349,7 @@ public class UnbinderTest {
 
     JavaFileObject binding1Source = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -343,6 +359,7 @@ public class UnbinderTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -368,6 +385,7 @@ public class UnbinderTest {
     JavaFileObject binding2Source =
         JavaFileObjects.forSourceString("test/one/TestOne_ViewBinding", ""
             + "package test.one;\n"
+            + "import android.support.annotation.UiThread;\n"
             + "import android.view.View;\n"
             + "import butterknife.internal.DebouncingOnClickListener;\n"
             + "import butterknife.internal.Utils;\n"
@@ -375,6 +393,7 @@ public class UnbinderTest {
             + "import test.Test_ViewBinding;\n"
             + "public class TestOne_ViewBinding<T extends TestOne> extends Test_ViewBinding<T> {\n"
             + "  private View view2;\n"
+            + "  @UiThread\n"
             + "  public TestOne_ViewBinding(final T target, View source) {\n"
             + "    super(target, source);\n"
             + "    View view;\n"
@@ -397,6 +416,7 @@ public class UnbinderTest {
         );
 
     assertAbout(javaSources()).that(asList(source1, source2))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -429,6 +449,7 @@ public class UnbinderTest {
 
     JavaFileObject binding1Source = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
@@ -438,6 +459,7 @@ public class UnbinderTest {
         + "public class Test_ViewBinding<T extends Test> implements Unbinder {\n"
         + "  protected T target;\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(final T target, View source) {\n"
         + "    this.target = target;\n"
         + "    View view;\n"
@@ -462,12 +484,14 @@ public class UnbinderTest {
 
     JavaFileObject binding2Source = JavaFileObjects.forSourceString("test/TestTwo_ViewBinding", ""
         + "package test;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class TestTwo_ViewBinding<T extends TestTwo> extends Test_ViewBinding<T> {\n"
         + "  private View view1;\n"
+        + "  @UiThread\n"
         + "  public TestTwo_ViewBinding(final T target, View source) {\n"
         + "    super(target, source);\n"
         + "    View view;\n"
@@ -490,6 +514,7 @@ public class UnbinderTest {
     );
 
     assertAbout(javaSources()).that(asList(source1, source2, source3))
+        .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ButterKnifeProcessor())
         .compilesWithoutWarnings()
         .and()
@@ -622,6 +647,7 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.Unbinder;\n"
         + "import butterknife.internal.Utils;\n"
@@ -635,9 +661,11 @@ public class UnbinderTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  public A_ViewBinding(T target, Context context) {\n"
         + "    this.target = target;\n"
         + "    Resources res = context.getResources();\n"
@@ -657,6 +685,7 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Deprecated;\n"
@@ -666,9 +695,11 @@ public class UnbinderTest {
         + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
         + "   */\n"
         + "  @Deprecated\n"
+        + "  @UiThread\n"
         + "  public Test_ViewBinding(T target, View source) {\n"
         + "    this(target, source.getContext());\n"
         + "  }\n"
+        + "  @UiThread\n"
         + "  public B_ViewBinding(T target, Context context) {\n"
         + "    super(target, context);\n"
         + "    Resources res = context.getResources();\n"
@@ -683,10 +714,12 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class C_ViewBinding<T extends C> extends B_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public C_ViewBinding(T target, View source) {\n"
         + "    super(target, source.getContext());\n"
         + "    target.button1 = Utils.findRequiredView(source, android.R.id.button1, \"field 'button1'\");\n"
@@ -708,9 +741,11 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "public class D_ViewBinding<T extends D> extends C_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public D_ViewBinding(T target, View source) {\n"
         + "    super(target, source);\n"
         + "    Context context = source.getContext();\n"
@@ -725,9 +760,11 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "public class E_ViewBinding<T extends E> extends C_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public E_ViewBinding(T target, View source) {\n"
         + "    super(target, source);\n"
         + "    Context context = source.getContext();\n"
@@ -742,9 +779,11 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "public class F_ViewBinding<T extends F> extends D_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public F_ViewBinding(T target, View source) {\n"
         + "    super(target, source);\n"
         + "    Context context = source.getContext();\n"
@@ -759,12 +798,14 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.DebouncingOnClickListener;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class G_ViewBinding<T extends G> extends E_ViewBinding<T> {\n"
         + "  private View view16908290;\n"
+        + "  @UiThread\n"
         + "  public G_ViewBinding(final T target, View source) {\n"
         + "    super(target, source);\n"
         + "    View view;\n"
@@ -797,10 +838,12 @@ public class UnbinderTest {
         + "package test;\n"
         + "import android.content.Context;\n"
         + "import android.content.res.Resources;\n"
+        + "import android.support.annotation.UiThread;\n"
         + "import android.view.View;\n"
         + "import butterknife.internal.Utils;\n"
         + "import java.lang.Override;\n"
         + "public class H_ViewBinding<T extends H> extends G_ViewBinding<T> {\n"
+        + "  @UiThread\n"
         + "  public H_ViewBinding(T target, View source) {\n"
         + "    super(target, source);\n"
         + "    target.button3 = Utils.findRequiredView(source, android.R.id.button3, \"field 'button3'\");\n"


### PR DESCRIPTION
This ensures that if they're used directly they're used from the proper thread.