### PR TITLE
Support libraries to 24.2.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ ext {
 }
 
 def androidToolsVersion = '25.1.2'
-def supportLibraryVersion = '24.2.0'
+def supportLibraryVersion = '24.2.1'
 def butterknifeLatestReleaseVersion = '8.4.0'
 
 ext.deps = [


### PR DESCRIPTION
Google deleted 24.2.0 out from under us. Thanks, Obama.