### PR TITLE
Remove gradle internal api usage

### DIFF
--- a/butterknife/build.gradle
+++ b/butterknife/build.gradle
@@ -33,9 +33,23 @@ dependencies {
   testCompile deps.junit
   testCompile deps.truth
   testCompile deps.compiletesting
-  testCompile files(org.gradle.internal.jvm.Jvm.current().getRuntimeJar())
+  testCompile files(getRuntimeJar())
   testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
   testCompile project(':butterknife-compiler')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+def File getRuntimeJar() {
+  try {
+  final File javaBase = new File(System.getProperty("java.home")).getCanonicalFile()
+  File runtimeJar = new File(javaBase, "lib/rt.jar")
+  if (runtimeJar.exists()) {
+    return runtimeJar
+  }
+  runtimeJar = new File(javaBase, "jre/lib/rt.jar")
+  return runtimeJar.exists() ? runtimeJar : null
+  } catch (IOException e) {
+    throw new RuntimeException(e)
+  }
+}


### PR DESCRIPTION
Gradle 3.1 removes the `org.gradle.internal.jvm.Jvm.current().getRuntimeJar()` api
