### PR TITLE
Fix RegexpSingleline in checkstyle rules

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -16,7 +16,7 @@
 
   <!-- Space after 'for' and 'if' -->
   <module name="RegexpSingleline">
-    <property name="format" value="^\s*(for|if)[^ ]"/>
+    <property name="format" value="^\s*(for|if)\b[^ ]"/>
     <property name="message" value="Space needed before opening parenthesis."/>
   </module>
 


### PR DESCRIPTION
For example:
word 'foreground' don't pass checkstyle