### PR TITLE
Fix listener method type checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ subprojects { project ->
   version = VERSION_NAME
 
   repositories {
+    mavenCentral()
     maven {
       url "https://plugins.gradle.org/m2/"
     }
@@ -30,6 +31,7 @@ subprojects { project ->
 
   buildscript {
     repositories {
+      mavenCentral()
       maven {
         url "https://plugins.gradle.org/m2/"
       }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -1037,7 +1037,9 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
           if (methodParameterUsed.get(j)) {
             continue;
           }
-          if (isSubtypeOfType(methodParameterType, parameterTypes[j])
+          if ((isSubtypeOfType(methodParameterType, parameterTypes[j])
+                  && isSubtypeOfType(methodParameterType, VIEW_TYPE))
+              || isTypeEqual(methodParameterType, parameterTypes[j])
               || isInterface(methodParameterType)) {
             parameters[i] = new Parameter(j, TypeName.get(methodParameterType));
             methodParameterUsed.set(j);
@@ -1103,7 +1105,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
   }
 
   private boolean isSubtypeOfType(TypeMirror typeMirror, String otherType) {
-    if (otherType.equals(typeMirror.toString())) {
+    if (isTypeEqual(typeMirror, otherType)) {
       return true;
     }
     if (typeMirror.getKind() != TypeKind.DECLARED) {
@@ -1140,6 +1142,10 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
       }
     }
     return false;
+  }
+
+  private boolean isTypeEqual(TypeMirror typeMirror, String otherType) {
+    return otherType.equals(typeMirror.toString());
   }
 
   private BindingSet.Builder getOrCreateBindingBuilder(

--- a/butterknife/src/test/java/butterknife/OnTextChangedTest.java
+++ b/butterknife/src/test/java/butterknife/OnTextChangedTest.java
@@ -75,4 +75,155 @@ public class OnTextChangedTest {
         .and()
         .generatesSources(bindingSource);
   }
+
+  @Test public void textChangedWithParameter() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+            + "package test;\n"
+            + "import android.app.Activity;\n"
+            + "import butterknife.OnTextChanged;\n"
+            + "public class Test extends Activity {\n"
+            + "  @OnTextChanged(1) void doStuff(CharSequence p0) {}\n"
+            + "}"
+    );
+
+    JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
+            + "package test;\n"
+            + "import android.support.annotation.CallSuper;\n"
+            + "import android.support.annotation.UiThread;\n"
+            + "import android.text.Editable;\n"
+            + "import android.text.TextWatcher;\n"
+            + "import android.view.View;\n"
+            + "import android.widget.TextView;\n"
+            + "import butterknife.Unbinder;\n"
+            + "import butterknife.internal.Utils;\n"
+            + "import java.lang.CharSequence;\n"
+            + "import java.lang.IllegalStateException;\n"
+            + "import java.lang.Override;\n"
+            + "public class Test_ViewBinding implements Unbinder {\n"
+            + "  private Test target;\n"
+            + "  private View view1;\n"
+            + "  private TextWatcher view1TextWatcher;\n"
+            + "  @UiThread\n"
+            + "  public Test_ViewBinding(final Test target, View source) {\n"
+            + "    this.target = target;\n"
+            + "    View view;\n"
+            + "    view = Utils.findRequiredView(source, 1, \"method 'doStuff'\");\n"
+            + "    view1 = view;\n"
+            + "    view1TextWatcher = new TextWatcher() {\n"
+            + "      @Override\n"
+            + "      public void onTextChanged(CharSequence p0, int p1, int p2, int p3) {\n"
+            + "        target.doStuff(p0);\n"
+            + "      }\n"
+            + "      @Override\n"
+            + "      public void beforeTextChanged(CharSequence p0, int p1, int p2, int p3) {\n"
+            + "      }\n"
+            + "      @Override\n"
+            + "      public void afterTextChanged(Editable p0) {\n"
+            + "      }\n"
+            + "    };\n"
+            + "    ((TextView) view).addTextChangedListener(view1TextWatcher);\n"
+            + "  }\n"
+            + "  @Override\n"
+            + "  @CallSuper\n"
+            + "  public void unbind() {\n"
+            + "    if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+            + "    target = null;\n"
+            + "    ((TextView) view1).removeTextChangedListener(view1TextWatcher);\n"
+            + "    view1TextWatcher = null;\n"
+            + "    view1 = null;\n"
+            + "  }\n"
+            + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+            .withCompilerOptions("-Xlint:-processing")
+            .processedWith(new ButterKnifeProcessor())
+            .compilesWithoutWarnings()
+            .and()
+            .generatesSources(bindingSource);
+  }
+
+  @Test public void textChangedWithParameters() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+            + "package test;\n"
+            + "import android.app.Activity;\n"
+            + "import butterknife.OnTextChanged;\n"
+            + "public class Test extends Activity {\n"
+            + "  @OnTextChanged(1) void doStuff(CharSequence p0, int p1, int p2, int p3) {}\n"
+            + "}"
+    );
+
+    JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
+            + "package test;\n"
+            + "import android.support.annotation.CallSuper;\n"
+            + "import android.support.annotation.UiThread;\n"
+            + "import android.text.Editable;\n"
+            + "import android.text.TextWatcher;\n"
+            + "import android.view.View;\n"
+            + "import android.widget.TextView;\n"
+            + "import butterknife.Unbinder;\n"
+            + "import butterknife.internal.Utils;\n"
+            + "import java.lang.CharSequence;\n"
+            + "import java.lang.IllegalStateException;\n"
+            + "import java.lang.Override;\n"
+            + "public class Test_ViewBinding implements Unbinder {\n"
+            + "  private Test target;\n"
+            + "  private View view1;\n"
+            + "  private TextWatcher view1TextWatcher;\n"
+            + "  @UiThread\n"
+            + "  public Test_ViewBinding(final Test target, View source) {\n"
+            + "    this.target = target;\n"
+            + "    View view;\n"
+            + "    view = Utils.findRequiredView(source, 1, \"method 'doStuff'\");\n"
+            + "    view1 = view;\n"
+            + "    view1TextWatcher = new TextWatcher() {\n"
+            + "      @Override\n"
+            + "      public void onTextChanged(CharSequence p0, int p1, int p2, int p3) {\n"
+            + "        target.doStuff(p0, p1, p2, p3);\n"
+            + "      }\n"
+            + "      @Override\n"
+            + "      public void beforeTextChanged(CharSequence p0, int p1, int p2, int p3) {\n"
+            + "      }\n"
+            + "      @Override\n"
+            + "      public void afterTextChanged(Editable p0) {\n"
+            + "      }\n"
+            + "    };\n"
+            + "    ((TextView) view).addTextChangedListener(view1TextWatcher);\n"
+            + "  }\n"
+            + "  @Override\n"
+            + "  @CallSuper\n"
+            + "  public void unbind() {\n"
+            + "    if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+            + "    target = null;\n"
+            + "    ((TextView) view1).removeTextChangedListener(view1TextWatcher);\n"
+            + "    view1TextWatcher = null;\n"
+            + "    view1 = null;\n"
+            + "  }\n"
+            + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+            .withCompilerOptions("-Xlint:-processing")
+            .processedWith(new ButterKnifeProcessor())
+            .compilesWithoutWarnings()
+            .and()
+            .generatesSources(bindingSource);
+  }
+
+  @Test public void textChangedWithWrongParameter() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+            + "package test;\n"
+            + "import android.app.Activity;\n"
+            + "import butterknife.OnTextChanged;\n"
+            + "public class Test extends Activity {\n"
+            + "  @OnTextChanged(1) void doStuff(String p0, int p1, int p2, int p3) {}\n"
+            + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+            .withCompilerOptions("-Xlint:-processing")
+            .processedWith(new ButterKnifeProcessor())
+            .failsToCompile();
+  }
+
 }


### PR DESCRIPTION
Fix #782 

- Add checking to listener method parameter to allow using subtype of original method's type only when the parameter is subtype of view.

- Add testcase in OnTextChangedTest.java