### PR TITLE
[Lint] Migrate to new PSI API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }
 
-def androidToolsVersion = '25.1.2'
+def androidToolsVersion = '25.2.0'
 def supportLibraryVersion = '24.2.1'
 def butterknifeLatestReleaseVersion = '8.4.0'
 

--- a/butterknife-lint/src/main/java/butterknife/lint/InvalidR2UsageDetector.java
+++ b/butterknife-lint/src/main/java/butterknife/lint/InvalidR2UsageDetector.java
@@ -67,7 +67,6 @@ public class InvalidR2UsageDetector extends Detector implements Detector.JavaPsi
     }
 
     private static void detectR2(JavaContext context, PsiElement node) {
-      System.out.println("visiting " + node.getText() + ", parent=" + node.getParent().getParent().getClass());
       PsiClass[] classes = context.getJavaFile().getClasses();
       if (classes.length > 0 && classes[0].getName() != null) {
         String qualifiedName = classes[0].getName();
@@ -79,7 +78,6 @@ public class InvalidR2UsageDetector extends Detector implements Detector.JavaPsi
       }
       boolean isR2 = isR2Expression(node);
       if (isR2 && !context.isSuppressedWithComment(node, ISSUE)) {
-        System.out.println("about to report " + node.getText());
         context.report(ISSUE, node, context.getLocation(node), LINT_ERROR_BODY);
       }
     }

--- a/butterknife-lint/src/main/java/butterknife/lint/InvalidR2UsageDetector.java
+++ b/butterknife-lint/src/main/java/butterknife/lint/InvalidR2UsageDetector.java
@@ -1,31 +1,30 @@
 package butterknife.lint;
 
-import com.android.annotations.NonNull;
 import com.android.tools.lint.detector.api.Category;
-import com.android.tools.lint.detector.api.Context;
 import com.android.tools.lint.detector.api.Detector;
 import com.android.tools.lint.detector.api.Implementation;
 import com.android.tools.lint.detector.api.Issue;
 import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.LintUtils;
 import com.android.tools.lint.detector.api.Scope;
 import com.android.tools.lint.detector.api.Severity;
 import com.google.common.collect.ImmutableSet;
-import java.io.File;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.JavaRecursiveElementVisitor;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiReferenceExpression;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
-import lombok.ast.Annotation;
-import lombok.ast.AstVisitor;
-import lombok.ast.ClassDeclaration;
-import lombok.ast.ForwardingAstVisitor;
-import lombok.ast.Identifier;
-import lombok.ast.Node;
-import lombok.ast.Select;
-import lombok.ast.VariableReference;
 
 /**
  * Custom lint rule to make sure that generated R2 is not referenced outside annotations.
  */
-public class InvalidR2UsageDetector extends Detector implements Detector.JavaScanner {
-
+public class InvalidR2UsageDetector extends Detector implements Detector.JavaPsiScanner {
   private static final String LINT_ERROR_BODY = "R2 should only be used inside annotations";
   private static final String LINT_ERROR_TITLE = "Invalid usage of R2";
   private static final String ISSUE_ID = "InvalidR2Usage";
@@ -39,46 +38,66 @@ public class InvalidR2UsageDetector extends Detector implements Detector.JavaSca
 
   private static final String R2 = "R2";
 
-  @Override public boolean appliesTo(@NonNull Context context, @NonNull File file) {
-    // skip generated files
-    String name = file.getName();
-    return !name.contains("_ViewBinder") && !name.contains("_ViewBinding");
+  @Override public List<Class<? extends PsiElement>> getApplicablePsiTypes() {
+    return Collections.<Class<? extends PsiElement>>singletonList(PsiClass.class);
   }
 
-  @Override public AstVisitor createJavaVisitor(@NonNull JavaContext javaContext) {
-    final JavaContext context = javaContext;
-    return new ForwardingAstVisitor() {
-
-      @Override public boolean visitClassDeclaration(ClassDeclaration node) {
-        // skip R2
-        return R2.equals(node.astName().astValue());
-      }
-
-      @Override public boolean visitAnnotation(Annotation node) {
-        // skip annotations
-        return true;
-      }
-
-      @Override public boolean visitSelect(Select node) {
-        return detectR2(context, node, node.astIdentifier());
-      }
-
-      @Override public boolean visitVariableReference(VariableReference node) {
-        return detectR2(context, node, node.astIdentifier());
+  @Override public JavaElementVisitor createPsiVisitor(final JavaContext context) {
+    return new JavaElementVisitor() {
+      @Override public void visitClass(PsiClass node) {
+        node.accept(new R2UsageVisitor(context));
       }
     };
   }
 
-  private static boolean detectR2(JavaContext context, Node node, Identifier identifier) {
-    boolean isR2 = node.getParent() != null
-        && (identifier.toString().equals(R2) || identifier.toString().contains(".R2."))
-        && node.getParent() instanceof Select
-        && SUPPORTED_TYPES.contains(((Select) node.getParent()).astIdentifier().toString());
+  private static class R2UsageVisitor extends JavaRecursiveElementVisitor {
+    private final JavaContext context;
 
-    if (isR2 && !context.isSuppressedWithComment(node, ISSUE)) {
-      context.report(ISSUE, node, context.getLocation(identifier), LINT_ERROR_BODY);
+    R2UsageVisitor(JavaContext context) {
+      this.context = context;
     }
 
-    return isR2;
+    @Override public void visitAnnotation(PsiAnnotation annotation) {
+      // skip annotations
+    }
+
+    @Override public void visitReferenceExpression(PsiReferenceExpression expression) {
+      detectR2(context, expression);
+      super.visitReferenceExpression(expression);
+    }
+
+    private static void detectR2(JavaContext context, PsiElement node) {
+      System.out.println("visiting " + node.getText() + ", parent=" + node.getParent().getParent().getClass());
+      PsiClass[] classes = context.getJavaFile().getClasses();
+      if (classes.length > 0 && classes[0].getName() != null) {
+        String qualifiedName = classes[0].getName();
+        if (qualifiedName.contains("_ViewBinder") || qualifiedName.contains("_ViewBinding")
+            || qualifiedName.equals(R2)) {
+          // skip generated files and R2
+          return;
+        }
+      }
+      boolean isR2 = isR2Expression(node);
+      if (isR2 && !context.isSuppressedWithComment(node, ISSUE)) {
+        System.out.println("about to report " + node.getText());
+        context.report(ISSUE, node, context.getLocation(node), LINT_ERROR_BODY);
+      }
+    }
+
+    private static boolean isR2Expression(PsiElement node) {
+      if (node.getParent() == null) {
+        return false;
+      }
+      String text = node.getText();
+      PsiElement parent = LintUtils.skipParentheses(node.getParent());
+      return (text.equals(R2) || text.contains(".R2"))
+          && parent instanceof PsiExpression
+          && endsWithAny(parent.getText(), SUPPORTED_TYPES);
+    }
+
+    private static boolean endsWithAny(String text, Set<String> possibleValues) {
+      String[] tokens = text.split("\\.");
+      return tokens.length > 1 && possibleValues.contains(tokens[tokens.length - 1]);
+    }
   }
 }

--- a/butterknife-lint/src/test/java/butterknife/lint/InvalidR2UsageDetectorTest.java
+++ b/butterknife-lint/src/test/java/butterknife/lint/InvalidR2UsageDetectorTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public class InvalidR2UsageDetectorTest extends LintDetectorTestBase {
-
   private static final String PATH_TEST_RESOURCES = "/src/test/java/sample/r2/";
   private static final String NO_WARNINGS = "No warnings.";
   private static final String R2 = "R2.java";


### PR DESCRIPTION
I was able to confirm that the ButterKnife custom lint was the reason for this issue with Retrolambda to resurface: https://github.com/evant/gradle-retrolambda/issues/96
Apparently, if you have any custom lint rules using the old lombok API, the linter will run it twice, both with the old and with the new API, making the lint slower and also causing it to spit enourmous amounts of stacktraces due to the retrolambda incompatibility, as described in the issue linked above.
Unfortunately, the custom lombok ast build stopped working for reasons I can't understand, but fixing the butterknife linter should be enough to have the linter stop spitting stacktraces (as long as you don't have any other custom lint rules using the lombok api).
This PR migrates the custom R2 lint rule to the new PSI API
Sorry if the description got confusing, it's 2:35am 😴 