### PR TITLE
use getClassLoader().loadClass() replace for Class.forName , because …

### DIFF
--- a/butterknife/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife/src/main/java/butterknife/ButterKnife.java
@@ -226,7 +226,7 @@ public final class ButterKnife {
       return null;
     }
     try {
-      Class<?> bindingClass = Class.forName(clsName + "_ViewBinding");
+      Class<?> bindingClass = cls.getClassLoader().loadClass(clsName + "_ViewBinding");
       //noinspection unchecked
       bindingCtor = (Constructor<? extends Unbinder>) bindingClass.getConstructor(cls, View.class);
       if (debug) Log.d(TAG, "HIT: Loaded binding class and constructor.");


### PR DESCRIPTION
for our atlas project , business has bundle ClassLoader , if the ButterKnife is in maindex, the Class.forName can't load the class in the bundle . so if you can use class.getClassLoader() instead , thanks