### PR TITLE
Added support for binding animation resources

### DIFF
--- a/butterknife-annotations/src/main/java/butterknife/BindAnim.java
+++ b/butterknife-annotations/src/main/java/butterknife/BindAnim.java
@@ -1,0 +1,21 @@
+package butterknife;
+
+import android.support.annotation.AnimRes;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Bind a field to the specified animation resource ID.
+ * <pre><code>
+ * {@literal @}BindAnim(R.anim.fade_in) Animation fadeIn;
+ * </code></pre>
+ */
+@Retention(CLASS) @Target(FIELD)
+public @interface BindAnim {
+  /** Animation resource ID to which the field will be bound. */
+  @AnimRes int value();
+}

--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingSet.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingSet.java
@@ -52,6 +52,8 @@ final class BindingSet {
   static final ClassName BITMAP_FACTORY = ClassName.get("android.graphics", "BitmapFactory");
   static final ClassName CONTEXT_COMPAT =
       ClassName.get("android.support.v4.content", "ContextCompat");
+  static final ClassName ANIMATION_UTILS =
+          ClassName.get("android.view.animation", "AnimationUtils");
 
   private final TypeName targetTypeName;
   private final ClassName bindingClassName;

--- a/butterknife-compiler/src/main/java/butterknife/compiler/FieldAnimationBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/FieldAnimationBinding.java
@@ -22,6 +22,7 @@ final class FieldAnimationBinding implements ResourceBinding {
   }
 
   @Override public CodeBlock render(int sdk) {
-    return CodeBlock.of("target.$L = $T.loadAnimation(context, $L)", name, ANIMATION_UTILS, id.code);
+    return CodeBlock.of("target.$L = $T.loadAnimation(context, $L)", name, ANIMATION_UTILS,
+            id.code);
   }
 }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/FieldAnimationBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/FieldAnimationBinding.java
@@ -1,0 +1,27 @@
+package butterknife.compiler;
+
+import com.squareup.javapoet.CodeBlock;
+
+import static butterknife.compiler.BindingSet.ANIMATION_UTILS;
+
+final class FieldAnimationBinding implements ResourceBinding {
+  private final Id id;
+  private final String name;
+
+  FieldAnimationBinding(Id id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean requiresResources(int sdk) {
+    return false;
+  }
+
+  @Override public CodeBlock render(int sdk) {
+    return CodeBlock.of("target.$L = $T.loadAnimation(context, $L)", name, ANIMATION_UTILS, id.code);
+  }
+}

--- a/butterknife/src/test/java/butterknife/BindAnimTest.java
+++ b/butterknife/src/test/java/butterknife/BindAnimTest.java
@@ -1,0 +1,82 @@
+package butterknife;
+
+import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+import butterknife.compiler.ButterKnifeProcessor;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class BindAnimTest {
+  @Test public void simple() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.view.animation.Animation;\n"
+        + "import butterknife.BindAnim;\n"
+        + "public class Test {\n"
+        + "  @BindAnim(1) Animation one;\n"
+        + "}"
+    );
+
+    JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
+        + "// Generated code from Butter Knife. Do not modify!\n"
+        + "package test;\n"
+        + "import android.content.Context;\n"
+        + "import android.support.annotation.CallSuper;\n"
+        + "import android.support.annotation.UiThread;\n"
+        + "import android.view.View;\n"
+        + "import android.view.animation.AnimationUtils;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import java.lang.Deprecated;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "public class Test_ViewBinding implements Unbinder {\n"
+        + "  /**\n"
+        + "   * @deprecated Use {@link #Test_ViewBinding(Test, Context)} for direct creation.\n"
+        + "   *     Only present for runtime invocation through {@code ButterKnife.bind()}.\n"
+        + "   */\n"
+        + "  @Deprecated\n"
+        + "  @UiThread\n"
+        + "  public Test_ViewBinding(Test target, View source) {\n"
+        + "    this(target, source.getContext());\n"
+        + "  }\n"
+        + "  @UiThread\n"
+        + "  @SuppressWarnings(\"ResourceType\")\n"
+        + "  public Test_ViewBinding(Test target, Context context) {\n"
+        + "    target.one = AnimationUtils.loadAnimation(context, 1);\n"
+        + "  }\n"
+        + "  @Override\n"
+        + "  @CallSuper\n"
+        + "  public void unbind() {\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutWarnings()
+        .and()
+        .generatesSources(bindingSource);
+  }
+
+  @Test public void typeMustBeAnimation() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import butterknife.BindAnim;\n"
+        + "public class Test {\n"
+        + "  @BindAnim(1) String one;\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new ButterKnifeProcessor())
+        .failsToCompile()
+        .withErrorContaining("@BindAnim field type must be 'Animation'. (test.Test.one)")
+        .in(source).onLine(4);
+  }
+}


### PR DESCRIPTION
Related to the request in #870, this PR adds a new `@BindAnim` annotation, with which `Animation` resources can be bound to fields.

Example Usage:

```java
public class Test {
    @BindAnim(R.anim.fade_in)
    Animation fadeIn;
}
```

Generated code uses `AnimationUtils#loadAnimation` to retrieve the resource.

