### PR TITLE
Update to AGP 3.0.0a8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
       'buildTools': '26.0.0',
 
       'supportLibrary': '26.0.0',
-      'androidPlugin': '2.3.3',
+      'androidPlugin': '3.0.0-alpha8',
       'androidTools': '25.3.0',
       'kotlin': '1.1.3-2',
 

--- a/butterknife-annotations/build.gradle
+++ b/butterknife-annotations/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'checkstyle'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -11,7 +11,7 @@ checkstyle {
 
 dependencies {
   compileOnly deps.android.runtime
-  compile deps.support.annotations
+  api deps.support.annotations
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/butterknife-compiler/build.gradle
+++ b/butterknife-compiler/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'checkstyle'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -13,14 +13,14 @@ for (File file : sdkHandler.sdkLoader.repositories) {
 }
 
 dependencies {
-  compile project(':butterknife-annotations')
-  compile deps.auto.common
-  compile deps.javapoet
+  implementation project(':butterknife-annotations')
+  implementation deps.auto.common
+  api deps.javapoet
   compileOnly deps.auto.service
   compileOnly files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 
-  testCompile deps.junit
-  testCompile deps.truth
+  testImplementation deps.junit
+  testImplementation deps.truth
 }
 
 checkstyle {

--- a/butterknife-gradle-plugin/build.gradle
+++ b/butterknife-gradle-plugin/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -7,15 +7,15 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
   compileOnly gradleApi()
 
-  compile deps.android.gradlePlugin
-  compile deps.javaparser
-  compile deps.javapoet
-  compile deps.kotlin.stdLibJre8
+  implementation deps.android.gradlePlugin
+  implementation deps.javaparser
+  implementation deps.javapoet
+  implementation deps.kotlin.stdLibJre8
 
-  testCompile deps.junit
-  testCompile deps.truth
-  testCompile deps.support.annotations
-  testCompile deps.compiletesting
+  testImplementation deps.junit
+  testImplementation deps.truth
+  testImplementation deps.support.annotations
+  testImplementation deps.compiletesting
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
@@ -24,7 +24,7 @@ class ButterKnifePlugin : Plugin<Project> {
 
   private fun applyPlugin(variants: DomainObjectSet<out BaseVariant>) {
     variants.all { variant ->
-      variant.outputs.forEach { output ->
+      variant.outputs.all { output ->
         val processResources = output.processResources
         // TODO proper task registered as source-generating?
         processResources.doLast {

--- a/butterknife-integration-test/build.gradle
+++ b/butterknife-integration-test/build.gradle
@@ -32,13 +32,19 @@ android {
       proguardFile getDefaultProguardFile('proguard-android.txt')
     }
   }
+
+  testOptions {
+    unitTests {
+      includeAndroidResources = true
+    }
+  }
 }
 
 dependencies {
-  compile project(':butterknife')
+  implementation project(':butterknife')
   annotationProcessor project(':butterknife-compiler')
 
-  testCompile deps.junit
-  testCompile deps.truth
-  testCompile deps.robolectric
+  testImplementation deps.junit
+  testImplementation deps.truth
+  testImplementation deps.robolectric
 }

--- a/butterknife-lint/build.gradle
+++ b/butterknife-lint/build.gradle
@@ -1,17 +1,17 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'checkstyle'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  compile deps.lint.api
-  compile deps.lint.checks
+  implementation deps.lint.api
+  implementation deps.lint.checks
 
-  testCompile deps.junit
-  testCompile deps.lint.core
-  testCompile deps.lint.tests
-  testCompile(deps.truth) {
+  testImplementation deps.junit
+  testImplementation deps.lint.core
+  testImplementation deps.lint.tests
+  testImplementation(deps.truth) {
     exclude group: 'com.google.guava', module: 'guava'
   }
 }

--- a/butterknife/build.gradle
+++ b/butterknife/build.gradle
@@ -11,6 +11,12 @@ android {
     consumerProguardFiles 'proguard-rules.txt'
 
     testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+
+    javaCompileOptions {
+      annotationProcessorOptions {
+        includeCompileClasspath = true
+      }
+    }
   }
 
   lintOptions {
@@ -20,22 +26,22 @@ android {
 }
 
 dependencies {
-  compile project(':butterknife-annotations')
-  compile deps.support.annotations
-  compile deps.support.compat
+  api project(':butterknife-annotations')
+  implementation deps.support.annotations
+  api deps.support.compat
 
   lintRules project(':butterknife-lint')
 
-  androidTestCompile deps.junit
-  androidTestCompile deps.truth
-  androidTestCompile deps.support.test.runner
+  androidTestImplementation deps.junit
+  androidTestImplementation deps.truth
+  androidTestImplementation deps.support.test.runner
 
-  testCompile deps.junit
-  testCompile deps.truth
-  testCompile deps.compiletesting
-  testCompile files(getRuntimeJar())
-  testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
-  testCompile project(':butterknife-compiler')
+  testImplementation deps.junit
+  testImplementation deps.truth
+  testImplementation deps.compiletesting
+  testImplementation files(getRuntimeJar())
+  testImplementation files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
+  testImplementation project(':butterknife-compiler')
 }
 
 def getRuntimeJar() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-bin.zip

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -30,13 +30,13 @@ android {
 }
 
 dependencies {
-  compile deps.release.runtime
+  implementation deps.release.runtime
   annotationProcessor deps.release.compiler
 
-  compile project(':sample:library')
+  implementation project(':sample:library')
 
-  testCompile deps.junit
-  testCompile deps.truth
+  testImplementation deps.junit
+  testImplementation deps.truth
 }
 
 afterEvaluate {

--- a/sample/library/build.gradle
+++ b/sample/library/build.gradle
@@ -2,6 +2,7 @@ buildscript {
   repositories {
     mavenCentral()
     jcenter()
+    google()
   }
 
   dependencies {
@@ -22,9 +23,9 @@ android {
 }
 
 dependencies {
-  compile deps.release.runtime
+  implementation deps.release.runtime
   annotationProcessor deps.release.compiler
 
-  testCompile deps.junit
-  testCompile deps.truth
+  testImplementation deps.junit
+  testImplementation deps.truth
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ include ':butterknife-gradle-plugin'
 include ':butterknife-lint'
 include ':butterknife-integration-test'
 
-include ':sample:app'
-include ':sample:library'
+//include ':sample:app'
+//include ':sample:library'
 
 rootProject.name = 'butterknife-parent'


### PR DESCRIPTION
- Bump to Gradle 4.0-M1
- Bump to AGP 3.0.0-alpha8
- Update dependency configuration syntax
- Tell Robolectric to include Android resources in tests
- Update plugin usage of variant api