### PR TITLE
Speed up builds by racing emulator start.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,21 @@ android:
 jdk:
   - oraclejdk8
 
-before_script:
+before_install:
   # Install SDK license so Android Gradle plugin can install deps.
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  # Create and start an emulator for instrumentation tests.
+  # Create and start emulator for the script. Meant to race the install task.
   - echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
+
+install: ./gradlew clean assemble assembleAndroidTest --stacktrace
+
+before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82
+
+script: ./gradlew check connectedCheck --stacktrace
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/butterknife-integration-test/build.gradle
+++ b/butterknife-integration-test/build.gradle
@@ -24,6 +24,8 @@ android {
     warningsAsErrors true
     showAll true
     explainIssues true
+    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+    checkReleaseBuilds false
   }
 
   buildTypes {

--- a/butterknife/build.gradle
+++ b/butterknife/build.gradle
@@ -22,6 +22,8 @@ android {
   lintOptions {
     textReport true
     textOutput 'stdout'
+    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+    checkReleaseBuilds false
   }
 }
 


### PR DESCRIPTION
Also since we're splitting the commands, don't run lint release checks during compilation since the 'check' task will do a full lint run anyway.