### PR TITLE
Fix travis build by specifying distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: android
 
+dist: precise
+
 android:
   components:
     # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.


### PR DESCRIPTION
@JakeWharton 
Based on previous builds failing: https://travis-ci.org/JakeWharton/butterknife/builds/264107515?utm_source=github_status&utm_medium=notification

> This job ran on our Trusty environment, which is gradually becoming our default Linux environment. Read all about this in our blog: Trusty as a default Linux is coming and take note that you can add dist: precise in your .travis.yml file to continue using Precise.

TravisCI issue tracked here: https://github.com/travis-ci/travis-ci/issues/8123