### PR TITLE
Use avdmanager instead of deprecated android command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ android:
     # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.
     - tools
     - platform-tools
-    - sys-img-armeabi-v7a-android-18
 
 jdk:
   - oraclejdk8
@@ -14,9 +13,13 @@ before_install:
   # Install SDK license so Android Gradle plugin can install deps.
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+  # Install the rest of tools (e.g., avdmanager)
+  - sdkmanager tools
+  # Install the system image
+  - sdkmanager "system-images;android-18;default;armeabi-v7a"
   # Create and start emulator for the script. Meant to race the install task.
-  - echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-18;default;armeabi-v7a"
+  - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 install: ./gradlew clean assemble assembleAndroidTest --stacktrace
 


### PR DESCRIPTION
Looks like the Trusty Linux distribution isn't quite as complete as its Precise predecessor.

1) SDK Tools dir doesn't contain avdmanager, lint, etc.
```
$ ls /usr/local/android-sdk/tools/bin
sdkmanager
```
2) Travis no longer seems to recognize the configuration in the android.components section for system images
3) The emulator command has moved from tools to the sdk base dir.

This PR reflects and works around these limitations.