### PR TITLE
Make ButterknifeProcessor use significantly lesser memory during compilation

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/QualifiedId.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/QualifiedId.java
@@ -1,10 +1,12 @@
 package butterknife.compiler;
 
+import javax.lang.model.element.PackageElement;
+
 final class QualifiedId {
-  final String packageName;
+  final PackageElement packageName;
   final int id;
 
-  QualifiedId(String packageName, int id) {
+  QualifiedId(PackageElement packageName, int id) {
     this.packageName = packageName;
     this.id = id;
   }


### PR DESCRIPTION
Currently, Butterknife processor scans and parses all available `R` class files and their resources. When working with modules which have a large number of dependencies, the many merged `R` files from different packages and same resource identifiers lead to significant amount of memory required to maintain mappings of ids.

- This change makes Butterknife only maintain mapping of ids that are actually referenced in the various annotations.
- Some element instances have been converted to not be serialized to strings until necessary.

Doing so consumes significantly lesser memory and leads to faster compilation as well. Some snapshots of heap usage during compilation before and after

Before
=====
<img width="1205" alt="old_heap_uage" src="https://user-images.githubusercontent.com/291148/30308746-32d2f836-973c-11e7-92c0-5a8a46cef727.png">
<img width="840" alt="old_retained_heap" src="https://user-images.githubusercontent.com/291148/30308747-359cc4c0-973c-11e7-8a8c-615b25ac98f9.png">

After
====
<img width="898" alt="new_heap_usage" src="https://user-images.githubusercontent.com/291148/30310071-6017ae70-9743-11e7-98d7-9ad8107120c2.png">
<img width="757" alt="new_retained_heap" src="https://user-images.githubusercontent.com/291148/30310073-63177146-9743-11e7-99ba-f684a124282b.png">

The retained heap after the change is due to another [bug](https://github.com/typetools/checker-framework/issues/1482) not related to Butterknife.

As for build time, one of our largest modules (~2.5k java files) that uses butterknife modules went from 130s to 90s to build (about *30 %* savings)