### PR TITLE
Fix custom lint checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
       'buildTools': '26.0.1',
 
       'supportLibrary': '26.0.2',
-      'androidPlugin': '3.0.0-beta5',
-      'androidTools': '26.0.0-beta5',
+      'androidPlugin': '3.0.0-beta6',
+      'androidTools': '26.0.0-beta6',
       'kotlin': '1.1.4-3',
 
       'release': '8.8.1',
@@ -53,17 +53,14 @@ buildscript {
 
   repositories {
     mavenCentral()
+    jcenter()
     google()
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
   }
 
   dependencies {
     classpath deps.android.gradlePlugin
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
-    classpath 'gradle.plugin.com.kageiit:lintrules:1.1.3'
   }
 }
 
@@ -73,10 +70,8 @@ subprojects { project ->
 
   repositories {
     mavenCentral()
+    jcenter()
     google()
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
   }
 
   if (!project.name.equals('butterknife-gradle-plugin')) {

--- a/butterknife-lint/build.gradle
+++ b/butterknife-lint/build.gradle
@@ -5,8 +5,8 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  implementation deps.lint.api
-  implementation deps.lint.checks
+  compileOnly deps.lint.api
+  compileOnly deps.lint.checks
 
   testImplementation deps.junit
   testImplementation deps.lint.core
@@ -18,7 +18,7 @@ dependencies {
 
 jar {
   manifest {
-    attributes 'Lint-Registry': 'butterknife.lint.LintRegistry'
+    attributes 'Lint-Registry-v2': 'butterknife.lint.LintRegistry'
   }
 }
 

--- a/butterknife/build.gradle
+++ b/butterknife/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.kageiit.lintrules'
 
 android {
   compileSdkVersion versions.compileSdk
@@ -32,7 +31,7 @@ dependencies {
   implementation deps.support.annotations
   api deps.support.compat
 
-  lintRules project(':butterknife-lint')
+  lintChecks project(':butterknife-lint')
 
   androidTestImplementation deps.junit
   androidTestImplementation deps.truth


### PR DESCRIPTION
* Update AGP and Lint to beta6.
* Update lint dependencies to 'compileOnly' configuration
* Replace lintrules plugin with built-in lint configuration
* Update to new Lint Registry for UAST support
* Replace Gradle plugins repo with jcenter

See https://issuetracker.google.com/issues/62914381#comment23