### PR TITLE
Removed support.annotations dependency from Butterknife

### DIFF
--- a/butterknife/build.gradle
+++ b/butterknife/build.gradle
@@ -27,7 +27,6 @@ android {
 
 dependencies {
   api project(':butterknife-annotations')
-  implementation deps.support.annotations
   api deps.support.compat
 
   lintChecks project(':butterknife-lint')


### PR DESCRIPTION
While learning the difference between api/implementation I noticed that:

 -  `butterknife-annotations` exposes `deps.support.annotations`
 - `butterknife` depends on `butterknife-annotations`
 - `butterknife` has `implementation deps.support.annotations`

So, `butterknife` doesn't need `deps.support.annotations`.

Does it make sense?
