### PR TITLE
For android gradle plugin 3.1.0-alpha01, update the butterknife gradl…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
       'compileSdk': 26,
 
       'supportLibrary': '27.0.0',
-      'androidPlugin': '3.0.0',
+      'androidPlugin': '3.1.0-alpha01',
       'androidTools': '26.0.0',
       'kotlin': '1.1.51',
 


### PR DESCRIPTION
**Android gradle plugin 3.1.0-alpha01 Version**:
In `ProcessAndroidResources`, there is no `packageForR` field. Will throw an exception:

```shell
Error:A problem occurred configuring project ':app'.
> Could not determine the dependencies of task ':app:processDebugResources'.
   > Could not resolve all dependencies for configuration ':app:debugCompileClasspath'.
      > A problem occurred configuring project ':widget'.
         > Failed to notify project evaluation listener.
            > com.android.build.gradle.tasks.ProcessAndroidResources.getPackageForR()Ljava/lang/String;
```



This will cause gradle compilation to fail.

---

In the **Android gradle plugin 3.0 version** `ProcessAndroidResources` source, found a section on the `packageForR` assignment code:

```java
processResources.packageForR =
                        TaskInputHelper.memoize(
                                () -> {
                                    String splitName = config.getSplitFromManifest();
                                    if (splitName == null) {
                                        return config.getOriginalApplicationId();
                                    } else {
                                        return config.getOriginalApplicationId() + "." + splitName;
                                    }
                                });
```

With reference to this code, by way of reflection, access to the `ProcessAndroidResources` field. And then set the value of the **R package**, making the normal operation.

This is when the android gradle plugin is upgraded, causing some fields to lose the problem. So, I think here can be used to reflect the way. Just what I think.