### PR TITLE
Remove android:components block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: android
 
-android:
-  components:
-    # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.
-    - tools
-    - platform-tools
-
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
As mentioned, can be removed since 3.0.0 of the plugin is out. I figured this is a good thing to do here since others might use this `travis.yml` as a template