### PR TITLE
Use `BaseVariant.getApplicationId()` to make ButterknifePlugin compatible with AGP 3.1.0-alpha07

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
       'compileSdk': 27,
 
       'supportLibrary': '27.0.2',
-      'androidPlugin': '3.0.1',
+      'androidPlugin': '3.1.0-alpha07',
       'androidTools': '26.0.1',
       'kotlin': '1.2.10',
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
       'compileSdk': 27,
 
       'supportLibrary': '27.0.2',
-      'androidPlugin': '3.1.0-alpha07',
+      'androidPlugin': '3.0.1',
       'androidTools': '26.0.1',
       'kotlin': '1.2.10',
 

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
@@ -56,7 +56,7 @@ class ButterKnifePlugin : Plugin<Project> {
         // Though there might be multiple outputs, their R files are all the same. Thus, we only
         // need to configure the task once with the R.java input and action.
         if (once.compareAndSet(false, true)) {
-          val rPackage = processResources.originalApplicationId
+          val rPackage = variant.applicationId
           val pathToR = rPackage.replace('.', File.separatorChar)
           val rFile = processResources.sourceOutputDir.resolve(pathToR).resolve("R.java")
 


### PR DESCRIPTION
Use `BaseVariant.getApplicationId()` instead of `ProcessAndroidResources.getOriginalApplicationId()` which was moved to an internal class `LinkApplicationAndroidResourcesTask` in `AGP 3.1.0-alpha07`
  