### PR TITLE
Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,20 @@
+container:
+  image: cirrusci/android-sdk:18
+  cpu: 4
+  memory: 12G
+
+check_task:
+  create_device_script: >
+    echo no | avdmanager create avd --force \
+        -n test \
+        -k "system-images;android-18;default;armeabi-v7a"
+  start_emulator_background_script: >
+    $ANDROID_HOME/emulator/emulator \
+        -avd test \
+        -no-audio \
+        -no-window
+  assemble_script: ./gradlew assemble assembleAndroidTest
+  wait_for_emulator_script:
+    - adb wait-for-device
+    - adb shell input keyevent 82
+  check_script: ./gradlew check connectedCheck --stacktrace

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,8 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=jakewharton
 POM_DEVELOPER_NAME=Jake Wharton
 
+org.gradle.daemon=true
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx1536M

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,17 @@ include ':butterknife-integration-test'
 //include ':sample:library'
 
 rootProject.name = 'butterknife-parent'
+
+ext.isCiServer = System.getenv().containsKey("CI")
+ext.isMasterBranch = System.getenv()["CIRRUS_BRANCH"] == "master"
+
+buildCache {
+    local {
+        enabled = !isCiServer
+    }
+    remote(HttpBuildCache) {
+        url = 'http://' + System.getenv().getOrDefault("CIRRUS_HTTP_CACHE_HOST", "localhost:12321") + "/"
+        enabled = isCiServer
+        push = isMasterBranch
+    }
+}


### PR DESCRIPTION
I was testing Android capabilities of Cirrus CI for [a blog post](https://medium.com/cirruslabs/speeding-up-android-builds-with-cirrus-ci-9e20ab7c5150) and found out that Cirrus CI is approximately **3-4 times faster** (4 minutes instead of 13-16 minutels right now).

Here is a [Cirrus CI build](https://cirrus-ci.com/task/5077208682987520) for this change:

![image](https://user-images.githubusercontent.com/989066/35237885-d97a1f20-ff79-11e7-8dc6-c7873452d643.png)

Just wanted to let you know in case you are interested in a new CI. **Feel free to close this PR** if you are not interested. Didn't want to just throw this work away. 😅

PS in case you'll want to merge this change, install [Cirrus CI App](https://github.com/apps/cirrus-ci) (it's free for OSS) on this particular repository as described in [Cirrus CI documentation](http://cirrus-ci.org/#/quick-start).