### PR TITLE
Parse manifest to determine package name.

### DIFF
--- a/butterknife-gradle-plugin/build.gradle
+++ b/butterknife-gradle-plugin/build.gradle
@@ -1,8 +1,17 @@
-apply plugin: 'java-library'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
+configurations {
+  fixtureClasspath
+}
+// Append any extra dependencies to the test fixtures via a custom configuration classpath. This
+// allows us to apply additional plugins in a fixture while still leveraging dependency resolution
+// and de-duplication semantics.
+def metadata = tasks.getByName('pluginUnderTestMetadata')
+metadata.setPluginClasspath(metadata.getPluginClasspath() + configurations.fixtureClasspath)
 
 dependencies {
   compileOnly gradleApi()

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
@@ -7,6 +7,7 @@ import com.android.build.gradle.FeaturePlugin
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
+import groovy.util.XmlSlurper
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -39,6 +40,18 @@ class ButterKnifePlugin : Plugin<Project> {
     }
   }
 
+  // Parse the variant's main manifest file in order to get the package id which is used to create
+  // R.java in the right place.
+  private fun getPackageName(variant : BaseVariant) : String {
+    val slurper = XmlSlurper(false, false)
+    val list = variant.sourceSets.map { it.manifestFile }
+
+    // According to the documentation, the earlier files in the list are meant to be overridden by the later ones.
+    // So the first file in the sourceSets list should be main.
+    val result = slurper.parse(list[0])
+    return result.getProperty("@package").toString()
+  }
+
   private fun configureR2Generation(project: Project, variants: DomainObjectSet<out BaseVariant>) {
     variants.all { variant ->
       val outputDir = project.buildDir.resolve(
@@ -48,6 +61,7 @@ class ButterKnifePlugin : Plugin<Project> {
       task.outputs.dir(outputDir)
       variant.registerJavaGeneratingTask(task, outputDir)
 
+      val rPackage = getPackageName(variant)
       val once = AtomicBoolean()
       variant.outputs.all { output ->
         val processResources = output.processResources
@@ -56,7 +70,6 @@ class ButterKnifePlugin : Plugin<Project> {
         // Though there might be multiple outputs, their R files are all the same. Thus, we only
         // need to configure the task once with the R.java input and action.
         if (once.compareAndSet(false, true)) {
-          val rPackage = variant.applicationId
           val pathToR = rPackage.replace('.', File.separatorChar)
           val rFile = processResources.sourceOutputDir.resolve(pathToR).resolve("R.java")
 

--- a/butterknife-gradle-plugin/src/test/AndroidManifest.xml
+++ b/butterknife-gradle-plugin/src/test/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.example.butterknife"/>

--- a/butterknife-gradle-plugin/src/test/build.gradle
+++ b/butterknife-gradle-plugin/src/test/build.gradle
@@ -1,0 +1,66 @@
+plugins {
+    id 'com.android.application'
+    id 'com.jakewharton.butterknife'
+}
+
+repositories {
+    google()
+}
+
+android {
+    compileSdkVersion 27
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_7
+        targetCompatibility = JavaVersion.VERSION_1_7
+    }
+
+    defaultConfig {
+        // This is different than the manifest.
+        applicationId 'com.example.butterknife'
+        minSdkVersion 27
+        targetSdkVersion 27
+        versionCode 1
+        versionName '1.0.0'
+    }
+
+    // Add differing applicationIdSuffixes for debug and release to ensure that the gradle plugin
+    // finds the R.java file correctly.
+    buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+        }
+        release {
+            applicationIdSuffix = ".release"
+        }
+    }
+
+    flavorDimensions "flavorA"
+
+    // Override the applicationId in flavors to ensure that the gradle plugin
+    // finds the R.java file correctly.
+    productFlavors {
+        flavorA {
+            applicationId "foo.bar"
+        }
+
+        flavorB {
+            applicationId "bar.foo"
+        }
+    }
+
+    sourceSets {
+        main.java.srcDirs += '../../../../../butterknife/src/main/java'
+        main.java.srcDirs += '../../../../../butterknife-annotations/src/main/java'
+    }
+
+    lintOptions {
+        checkReleaseBuilds false
+    }
+
+}
+
+dependencies {
+    implementation "com.android.support:support-annotations:27.0.2"
+    implementation "com.android.support:support-v4:27.0.2"
+}

--- a/butterknife-gradle-plugin/src/test/fixtures/suffix_parsed_properly/src/main/java/butterknife/test/ButteryActivity.java
+++ b/butterknife-gradle-plugin/src/test/fixtures/suffix_parsed_properly/src/main/java/butterknife/test/ButteryActivity.java
@@ -1,0 +1,21 @@
+package butterknife.test;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.TextView;
+import butterknife.ButterKnife;
+import butterknife.BindView;
+import com.example.butterknife.R;
+import com.example.butterknife.R2;
+
+class ButteryActivity extends Activity {
+
+  @BindView(R2.id.title) TextView title;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    ButterKnife.bind(this);
+
+  }
+
+}

--- a/butterknife-gradle-plugin/src/test/fixtures/suffix_parsed_properly/src/main/res/layout/activity_layout.xml
+++ b/butterknife-gradle-plugin/src/test/fixtures/suffix_parsed_properly/src/main/res/layout/activity_layout.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical"
+  android:padding="8dp"
+  tools:ignore="SelectableText">
+  <TextView
+    android:id="@+id/title"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:textSize="50sp"/>
+</LinearLayout>

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/AndroidHome.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/AndroidHome.kt
@@ -1,0 +1,25 @@
+package butterknife.plugin
+
+import java.io.File
+import java.util.Properties
+
+
+internal fun androidHome(): String {
+    val env = System.getenv("ANDROID_HOME")
+    if (env != null) {
+        return env
+    }
+    val localProp = File(File(System.getProperty("user.dir")).parentFile, "local.properties")
+    if (localProp.exists()) {
+        val prop = Properties()
+        localProp.inputStream().use {
+            prop.load(it)
+        }
+        val sdkHome = prop.getProperty("sdk.dir")
+        if (sdkHome != null) {
+            return sdkHome
+        }
+    }
+    throw IllegalStateException(
+            "Missing 'ANDROID_HOME' environment variable or local.properties with 'sdk.dir'")
+}

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/BuildFilesRule.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/BuildFilesRule.kt
@@ -1,0 +1,38 @@
+package butterknife.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.io.File
+
+class BuildFilesRule(private val root: File) : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                val buildFile = File(root, "build.gradle")
+                val hasBuildFile = buildFile.exists()
+                if (hasBuildFile) {
+                    assertThat(buildFile.readText())
+                } else {
+                    val buildFileTemplate = File(root, "../../build.gradle").readText()
+                    buildFile.writeText(buildFileTemplate)
+                }
+
+                val manifestFile = File(root, "src/main/AndroidManifest.xml")
+                val hasManifestFile = manifestFile.exists()
+                if (!hasManifestFile) {
+                    val manifestFileTemplate = File(root, "../../AndroidManifest.xml").readText()
+                    manifestFile.writeText(manifestFileTemplate)
+                }
+
+                try {
+                    base.evaluate()
+                } finally {
+                    if (!hasBuildFile) buildFile.delete()
+                    if (!hasManifestFile) manifestFile.delete()
+                }
+            }
+        }
+    }
+}

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/FixturesTest.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/FixturesTest.kt
@@ -1,0 +1,51 @@
+package butterknife.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.io.File
+
+
+@RunWith(Parameterized::class)
+class FixturesTest(val fixtureRoot: File, val name: String) {
+    @Suppress("unused") // Used by JUnit reflectively.
+    @get:Rule val buildFilesRule = BuildFilesRule(fixtureRoot)
+
+    @Test fun execute() {
+        val androidHome = androidHome()
+        File(fixtureRoot, "local.properties").writeText("sdk.dir=$androidHome\n")
+
+        val runner = GradleRunner.create()
+                .withProjectDir(fixtureRoot)
+                .withPluginClasspath()
+                .withArguments("clean", "assembleDebug", "assembleRelease", "--stacktrace")
+
+        if (File(fixtureRoot, "ignored.txt").exists()) {
+            println("Skipping ignored test $name.")
+            return
+        }
+
+        val expectedFailure = File(fixtureRoot, "failure.txt")
+        if (expectedFailure.exists()) {
+            val result = runner.buildAndFail()
+            for (chunk in expectedFailure.readText().split("\n\n")) {
+                assertThat(result.output).contains(chunk)
+            }
+        } else {
+            val result = runner.build()
+            assertThat(result.output).contains("BUILD SUCCESSFUL")
+        }
+    }
+
+    companion object {
+        @Suppress("unused") // Used by Parameterized JUnit runner reflectively.
+        @Parameters(name = "{1}")
+        @JvmStatic fun parameters() = File("src/test/fixtures").listFiles()
+                .filter { it.isDirectory }
+                .map { arrayOf(it, it.name) }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip


### PR DESCRIPTION
We don't want to use the applicationId to find the location of the
R.java file because the R.java file's location is based on the package
name not the applicationId.

The applicationId can change based on the variant, but the R.java file's
location will not change.

Added some tests to make sure this works based on the FixturesTest in
SQLDelight.

Fixes #1177