### PR TITLE
ButterKnife.findById methods are deprecated, don't encourage using them

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -202,14 +202,6 @@ void onNothingSelected() {
   // TODO ...
 }</pre>
 
-            <h4 id="bonus">Bonus</h4>
-            <p>Also included are <code>findById</code> methods which simplify code that still has to find views on a <code>View</code>, <code>Activity</code>, or <code>Dialog</code>. It uses generics to infer the return type and automatically performs the cast.</p>
-            <pre class="prettyprint">View view = LayoutInflater.from(context).inflate(R.layout.thing, null);
-TextView firstName = ButterKnife.findById(view, R.id.first_name);
-TextView lastName = ButterKnife.findById(view, R.id.last_name);
-ImageView photo = ButterKnife.findById(view, R.id.photo);</pre>
-            <p>Add a static import for <code>ButterKnife.findById</code> and enjoy even more fun.</p>
-
             <h3 id="download">Download</h3>
             <h4>Gradle</h4>
             <pre class="prettyprint">compile 'com.jakewharton:butterknife:<span class="version"><em>(insert latest version)</em></span>'


### PR DESCRIPTION
https://github.com/JakeWharton/butterknife/blob/master/CHANGELOG.md#version-880-2017-08-04
> Deprecate the findById methods. Compile against API 26 and use the normal findViewById for the same functionality.

(Exactly the same as #1168, same branch, same base, GitHub's "change base" doesn't seem to work, sorry about the mess there.)