### PR TITLE
Set API level in LintRegistry.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,10 @@ buildscript {
       'compileSdk': 27,
 
       'supportLibrary': '27.0.2',
-      'androidPlugin': '3.0.1',
-      'androidTools': '26.0.1',
-      'kotlin': '1.2.10',
+      'androidPlugin': '3.1.0-beta2',
+      'androidTools': '26.1.0-beta2',
+      'buildTools' : '27.0.1', // Set to older version until this is resolved: https://issuetracker.google.com/issues/73450622
+      'kotlin': '1.2.21',
 
       'release': '8.8.1',
   ]

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifePlugin.kt
@@ -86,6 +86,6 @@ class ButterKnifePlugin : Plugin<Project> {
   }
 
   private operator fun <T : Any> ExtensionContainer.get(type: KClass<T>): T {
-    return getByType(type.java)!!
+    return getByType(type.java)
   }
 }

--- a/butterknife-integration-test/build.gradle
+++ b/butterknife-integration-test/build.gradle
@@ -14,6 +14,7 @@ android {
     targetSdkVersion versions.compileSdk
     versionCode 1
     versionName '1.0.0'
+    buildToolsVersion versions.buildTools
   }
 
   lintOptions {

--- a/butterknife-lint/src/main/java/butterknife/lint/LintRegistry.java
+++ b/butterknife-lint/src/main/java/butterknife/lint/LintRegistry.java
@@ -1,6 +1,7 @@
 package butterknife.lint;
 
 import com.android.tools.lint.client.api.IssueRegistry;
+import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -12,5 +13,9 @@ public class LintRegistry extends IssueRegistry {
 
   @Override public List<Issue> getIssues() {
     return ImmutableList.of(InvalidR2UsageDetector.ISSUE);
+  }
+
+  @Override public int getApi() {
+    return ApiKt.CURRENT_API;
   }
 }


### PR DESCRIPTION
This avoids a warning when running lint with new versions of AGP.

Also update some dependency versions.