### PR TITLE
Fix R scanner behavior for array values

### DIFF
--- a/butterknife-annotations/src/main/java/butterknife/BindDrawable.java
+++ b/butterknife-annotations/src/main/java/butterknife/BindDrawable.java
@@ -5,6 +5,8 @@ import android.support.annotation.DrawableRes;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static butterknife.internal.Constants.NO_RES_ID;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
@@ -23,5 +25,5 @@ public @interface BindDrawable {
   @DrawableRes int value();
 
   /** Color attribute resource ID that is used to tint the drawable. */
-  @AttrRes int tint() default -1;
+  @AttrRes int tint() default NO_RES_ID;
 }

--- a/butterknife-annotations/src/main/java/butterknife/BindDrawable.java
+++ b/butterknife-annotations/src/main/java/butterknife/BindDrawable.java
@@ -23,5 +23,5 @@ public @interface BindDrawable {
   @DrawableRes int value();
 
   /** Color attribute resource ID that is used to tint the drawable. */
-  @AttrRes int tint() default 0;
+  @AttrRes int tint() default -1;
 }

--- a/butterknife-annotations/src/main/java/butterknife/internal/Constants.java
+++ b/butterknife-annotations/src/main/java/butterknife/internal/Constants.java
@@ -1,0 +1,5 @@
+package butterknife.internal;
+
+public class Constants {
+  public static final int NO_RES_ID = -1;
+}

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -74,6 +74,8 @@ import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
+import static butterknife.internal.Constants.NO_RES_ID;
+
 import static javax.lang.model.element.ElementKind.CLASS;
 import static javax.lang.model.element.ElementKind.INTERFACE;
 import static javax.lang.model.element.ElementKind.METHOD;
@@ -85,7 +87,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
   // TODO remove when http://b.android.com/187527 is released.
   private static final String OPTION_SDK_INT = "butterknife.minSdk";
   private static final String OPTION_DEBUGGABLE = "butterknife.debuggable";
-  static final Id NO_ID = new Id(-1);
+  static final Id NO_ID = new Id(NO_RES_ID);
   static final String VIEW_TYPE = "android.view.View";
   static final String ACTIVITY_TYPE = "android.app.Activity";
   static final String DIALOG_TYPE = "android.app.Dialog";
@@ -767,7 +769,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     Map<Integer, Id> resourceIds = elementToIds(element, BindDrawable.class, new int[] {id, tint});
 
     BindingSet.Builder builder = getOrCreateBindingBuilder(builderMap, enclosingElement);
-    builder.addResource(new FieldDrawableBinding(resourceIds.get(id), name, tint == -1 ? NO_ID : resourceIds.get(tint)));
+    builder.addResource(new FieldDrawableBinding(resourceIds.get(id), name, tint == NO_RES_ID ? NO_ID : resourceIds.get(tint)));
 
     erasedTargetNames.add(enclosingElement);
   }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -767,7 +767,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     Map<Integer, Id> resourceIds = elementToIds(element, BindDrawable.class, new int[] {id, tint});
 
     BindingSet.Builder builder = getOrCreateBindingBuilder(builderMap, enclosingElement);
-    builder.addResource(new FieldDrawableBinding(resourceIds.get(id), name, resourceIds.get(tint)));
+    builder.addResource(new FieldDrawableBinding(resourceIds.get(id), name, tint == -1 ? NO_ID : resourceIds.get(tint)));
 
     erasedTargetNames.add(enclosingElement);
   }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/FieldDrawableBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/FieldDrawableBinding.java
@@ -25,7 +25,7 @@ final class FieldDrawableBinding implements ResourceBinding {
   }
 
   @Override public CodeBlock render(int sdk) {
-    if (tintAttributeId.value != 0) {
+    if (tintAttributeId.value != -1) {
       return CodeBlock.of("target.$L = $T.getTintedDrawable(context, $L, $L)", name, UTILS, id.code,
           tintAttributeId.code);
     }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/FieldDrawableBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/FieldDrawableBinding.java
@@ -4,6 +4,7 @@ import com.squareup.javapoet.CodeBlock;
 
 import static butterknife.compiler.BindingSet.CONTEXT_COMPAT;
 import static butterknife.compiler.BindingSet.UTILS;
+import static butterknife.internal.Constants.NO_RES_ID;
 
 final class FieldDrawableBinding implements ResourceBinding {
   private final Id id;
@@ -25,7 +26,7 @@ final class FieldDrawableBinding implements ResourceBinding {
   }
 
   @Override public CodeBlock render(int sdk) {
-    if (tintAttributeId.value != -1) {
+    if (tintAttributeId.value != NO_RES_ID) {
       return CodeBlock.of("target.$L = $T.getTintedDrawable(context, $L, $L)", name, UTILS, id.code,
           tintAttributeId.code);
     }

--- a/butterknife/src/test/java/butterknife/BindViewsTest.java
+++ b/butterknife/src/test/java/butterknife/BindViewsTest.java
@@ -617,4 +617,101 @@ public class BindViewsTest {
         .withErrorContaining("@BindViews annotation contains duplicate ID 1. (test.Test.thing)")
         .in(source).onLine(6);
   }
+
+  @Test public void bindingArrayWithRScanner() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.R;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.BindViews;\n"
+        + "public class Test {\n"
+        + "    @BindViews({R.color.black, R.color.white}) View[] thing;\n"
+        + "}"
+    );
+
+    JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
+        + "package test;\n"
+        + "import android.support.annotation.CallSuper;\n"
+        + "import android.support.annotation.UiThread;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Utils;\n"
+        + "import java.lang.IllegalStateException;\n"
+        + "import java.lang.Override;\n"
+        + "public class Test_ViewBinding implements Unbinder {\n"
+        + "  private Test target;\n"
+        + "  @UiThread\n"
+        + "  public Test_ViewBinding(Test target, View source) {\n"
+        + "    this.target = target;\n"
+        + "    target.thing = Utils.arrayOf(\n"
+        + "        Utils.findRequiredView(source, android.R.color.black, \"field 'thing'\"), \n"
+        + "        Utils.findRequiredView(source, android.R.color.white, \"field 'thing'\"));\n"
+        + "  }\n"
+        + "  @Override\n"
+        + "  @CallSuper\n"
+        + "  public void unbind() {\n"
+        + "    Test target = this.target;\n"
+        + "    if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+        + "    this.target = null;\n"
+        + "    target.thing = null;\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutWarnings()
+        .and()
+        .generatesSources(bindingSource);
+  }
+
+  @Test public void bindingArrayWithMixedRAndLiteral() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import android.R;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.BindViews;\n"
+        + "public class Test {\n"
+        + "    @BindViews({R.color.black, 2, R.color.white}) View[] thing;\n"
+        + "}"
+    );
+
+    JavaFileObject bindingSource = JavaFileObjects.forSourceString("test/Test_ViewBinding", ""
+        + "package test;\n"
+        + "import android.support.annotation.CallSuper;\n"
+        + "import android.support.annotation.UiThread;\n"
+        + "import android.view.View;\n"
+        + "import butterknife.Unbinder;\n"
+        + "import butterknife.internal.Utils;\n"
+        + "import java.lang.IllegalStateException;\n"
+        + "import java.lang.Override;\n"
+        + "public class Test_ViewBinding implements Unbinder {\n"
+        + "  private Test target;\n"
+        + "  @UiThread\n"
+        + "  public Test_ViewBinding(Test target, View source) {\n"
+        + "    this.target = target;\n"
+        + "    target.thing = Utils.arrayOf(\n"
+        + "        Utils.findRequiredView(source, android.R.color.black, \"field 'thing'\"), \n"
+        + "        Utils.findRequiredView(source, 2, \"field 'thing'\"), \n"
+        + "        Utils.findRequiredView(source, android.R.color.white, \"field 'thing'\"));\n"
+        + "  }\n"
+        + "  @Override\n"
+        + "  @CallSuper\n"
+        + "  public void unbind() {\n"
+        + "    Test target = this.target;\n"
+        + "    if (target == null) throw new IllegalStateException(\"Bindings already cleared.\");\n"
+        + "    this.target = null;\n"
+        + "    target.thing = null;\n"
+        + "  }\n"
+        + "}"
+    );
+
+    assertAbout(javaSource()).that(source)
+        .withCompilerOptions("-Xlint:-processing")
+        .processedWith(new ButterKnifeProcessor())
+        .compilesWithoutWarnings()
+        .and()
+        .generatesSources(bindingSource);
+  }
 }


### PR DESCRIPTION
Fixes #1247 

- TreeScanner api visits all values at once when calling `accept(Tree)` so aggregate the symbols within the scanner itself
- Added new unit tests