### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,8 @@ subprojects { project ->
   version = VERSION_NAME
 
   repositories {
-    google()
     mavenCentral()
+    google()
     jcenter()
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,9 @@ subprojects { project ->
   version = VERSION_NAME
 
   repositories {
+    google()
     mavenCentral()
     jcenter()
-    google()
   }
 
   if (!project.name.equals('butterknife-gradle-plugin')) {


### PR DESCRIPTION
Change google() repository & jcenter() repository access priority so that the gradle build would not fail to resolve dependencies as per latest Android Studio update.

Reference: https://stackoverflow.com/questions/50584437/android-studio-3-1-2-failed-to-resolve-runtime/50758769