### PR TITLE
update proguard-rules

### DIFF
--- a/butterknife/proguard-rules.txt
+++ b/butterknife/proguard-rules.txt
@@ -3,6 +3,6 @@
 
 # Prevent obfuscation of types which use ButterKnife annotations since the simple name
 # is used to reflectively look up the generated ViewBinding.
--keep class butterknife.*
+-keep class butterknife.Butterknife
 -keepclasseswithmembernames class * { @butterknife.* <methods>; }
 -keepclasseswithmembernames class * { @butterknife.* <fields>; }


### PR DESCRIPTION
opt proguard-rules。annotations used on compile time only, after finish building APT file, annotations are useless