### PR TITLE
update proguard rules

### DIFF
--- a/butterknife/proguard-rules.txt
+++ b/butterknife/proguard-rules.txt
@@ -3,6 +3,6 @@
 
 # Prevent obfuscation of types which use ButterKnife annotations since the simple name
 # is used to reflectively look up the generated ViewBinding.
--keep class butterknife.*
+-keep class !butterknife.*$*
 -keepclasseswithmembernames class * { @butterknife.* <methods>; }
 -keepclasseswithmembernames class * { @butterknife.* <fields>; }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16160722/44202338-462b6380-a17e-11e8-83ef-9538113af21e.png)
The picture above shows the original class file.

![image](https://user-images.githubusercontent.com/16160722/44202372-5e9b7e00-a17e-11e8-9415-a5b3a08716b8.png)
and this picture above shows the new class file by using new proguard-rules.

Principle：as we all know, due to `@OnTextChanged` annotation has been kept by proguard-rule，so it could not be remove by proguard. But those inner class(enum) has been kept too, it's useless to keep those inner class(enum), they can be remove(like `OnTextChanged$Callback`), or can be shrinked(`ButterKnife$Action`、`ButterKnife$Setter`)