### PR TITLE
Add the google repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To use Butter Knife in a library, add the plugin to your `buildscript`:
 buildscript {
   repositories {
     mavenCentral()
+    google()
    }
   dependencies {
     classpath 'com.jakewharton:butterknife-gradle-plugin:10.0.0'


### PR DESCRIPTION
BK 10's plugin requires com.android.tools.build:gradle:3.1.4 and the google repo should be added to the buildscript's repos.

BK 10 also requires compileSDK 28, I don't know where the docs should reflect this.