### PR TITLE
Fix usage snippet in ButterKnife Reflect README

### DIFF
--- a/butterknife-reflect/README.md
+++ b/butterknife-reflect/README.md
@@ -33,7 +33,7 @@ Usage
 Kotlin modules:
 ```groovy
 dependencies {
-  if (properties.containsKey('android.injected.invoked.from.ide')) {
+  if (project.hasProperty('android.injected.invoked.from.ide')) {
     implementation 'com.jakewharton:butterknife-reflect:<version>'
   } else {
     implementation 'com.jakewharton:butterknife:<version>'
@@ -45,7 +45,7 @@ dependencies {
 Java modules:
 ```groovy
 dependencies {
-  if (properties.containsKey('android.injected.invoked.from.ide')) {
+  if (project.hasProperty('android.injected.invoked.from.ide')) {
     implementation 'com.jakewharton:butterknife-reflect:<version>'
   } else {
     implementation 'com.jakewharton:butterknife:<version>'


### PR DESCRIPTION
Using Android Studio 3.2 and Gradle 4.10.3, `properties.containsKey('android.injected.invoked.from.ide')` is always false.