### PR TITLE
Remove enforcement of required views in reflection backend

### DIFF
--- a/butterknife-integration-test/build.gradle
+++ b/butterknife-integration-test/build.gradle
@@ -15,7 +15,7 @@ android {
     versionCode 1
     versionName '1.0.0'
 
-    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }
 
   lintOptions {

--- a/butterknife-reflect/src/main/java/butterknife/ButterKnife.java
+++ b/butterknife-reflect/src/main/java/butterknife/ButterKnife.java
@@ -25,7 +25,6 @@ import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import butterknife.internal.Constants;
 import butterknife.internal.Utils;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -236,15 +235,9 @@ public final class ButterKnife {
     validateMember(field);
 
     int id = bindView.value();
-    boolean isRequired = isRequired(field);
     Class<?> viewClass = field.getType();
     String who = "field '" + field.getName() + "'";
-    Object view;
-    if (isRequired) {
-      view = Utils.findRequiredViewAsType(source, id, who, viewClass);
-    } else {
-      view = Utils.findOptionalViewAsType(source, id, who, viewClass);
-    }
+    Object view = Utils.findOptionalViewAsType(source, id, who, viewClass);
     trySet(field, target, view);
 
     return new FieldUnbinder(target, field);
@@ -276,16 +269,10 @@ public final class ButterKnife {
     }
 
     int[] ids = bindViews.value();
-    boolean isRequired = isRequired(field);
     List<Object> views = new ArrayList<>(ids.length);
     String who = "field '" + field.getName() + "'";
     for (int id : ids) {
-      Object view;
-      if (isRequired) {
-        view = Utils.findRequiredViewAsType(source, id, who, viewClass);
-      } else {
-        view = Utils.findOptionalViewAsType(source, id, who, viewClass);
-      }
+      Object view = Utils.findOptionalViewAsType(source, id, who, viewClass);
       if (view != null) {
         views.add(view);
       }
@@ -805,15 +792,6 @@ public final class ButterKnife {
           + method.getName()
           + " must have return type of "
           + expectedType);
-    }
-    return true;
-  }
-
-  private static boolean isRequired(Field field) {
-    for (Annotation annotation : field.getAnnotations()) {
-      if (annotation.annotationType().getSimpleName().equals("Nullable")) {
-        return false;
-      }
     }
     return true;
   }

--- a/butterknife-runtime/build.gradle
+++ b/butterknife-runtime/build.gradle
@@ -6,7 +6,7 @@ android {
   defaultConfig {
     minSdkVersion versions.minSdk
 
-    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
     javaCompileOptions {
       annotationProcessorOptions {

--- a/butterknife/build.gradle
+++ b/butterknife/build.gradle
@@ -8,7 +8,7 @@ android {
 
     consumerProguardFiles 'proguard-rules.txt'
 
-    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }
 
   compileOptions {


### PR DESCRIPTION
Almost all of the nullability annotations don't have runtime retention so this only causes problems. Also you'll get an NPE and it'll be obvious anyway, it just won't be eager.