### PR TITLE
Add @OnTextChanged support to reflect backend

### DIFF
--- a/butterknife-annotations/src/main/java/butterknife/OnTextChanged.java
+++ b/butterknife-annotations/src/main/java/butterknife/OnTextChanged.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Bind a method to a {@link TextWatcher TextWatcher} on the view for each ID specified.
@@ -32,7 +32,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * @see TextWatcher
  */
 @Target(METHOD)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @ListenerClass(
     targetType = "android.widget.TextView",
     setter = "addTextChangedListener",

--- a/butterknife-reflect/src/main/java/butterknife/ListenerUnbinder.java
+++ b/butterknife-reflect/src/main/java/butterknife/ListenerUnbinder.java
@@ -3,16 +3,24 @@ package butterknife;
 import android.view.View;
 import java.util.List;
 
-final class ListenerUnbinder<T extends View> implements Unbinder {
+final class ListenerUnbinder<T extends View, V> implements Unbinder {
   private final List<T> targets;
-  private final Setter<T, ?> setter;
+  private final Setter<T, V> setter;
+  private final V listener;
 
-  ListenerUnbinder(List<T> targets, Setter<T, ?> setter) {
+  ListenerUnbinder(List<T> targets, Setter<T, V> setter) {
     this.targets = targets;
     this.setter = setter;
+    this.listener = null;
+  }
+
+  ListenerUnbinder(List<T> targets, Setter<T, V> setter, V listener) {
+    this.targets = targets;
+    this.setter = setter;
+    this.listener = listener;
   }
 
   @Override public void unbind() {
-    ViewCollections.set(targets, setter, null);
+    ViewCollections.set(targets, setter, listener);
   }
 }


### PR DESCRIPTION
There is a potential optimization that could merge different callbacks on the same view into a common `TextWatcher`, which in this case probably wouldn't be worth it, despite _some_ extra allocations in current solution.

However it would still have to be done in case of `@OnItemSelected` since `AdapterView` only supports a single `OnItemSelectedListener`.