### PR TITLE
Support for generating Kotlin R2 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ class ExampleActivity extends Activity {
 }
 ```
 
+By default it will generate a Java R2 class. If you want kotlin, you can configure it via the plugin
+extension:
+
+```groovy
+butterKnife {
+  generateKotlin = true
+}
+```
 
 
 License

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
           'tests': "com.android.tools.lint:lint-tests:${versions.androidTools}",
       ],
       javapoet: 'com.squareup:javapoet:1.10.0',
+      kotlinpoet: 'com.squareup:kotlinpoet:1.0.1',
       junit: 'junit:junit:4.12',
       truth: 'com.google.truth:truth:0.42',
       compiletesting: 'com.google.testing.compile:compile-testing:0.15',

--- a/butterknife-gradle-plugin/build.gradle
+++ b/butterknife-gradle-plugin/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
   implementation deps.android.gradlePlugin
   implementation deps.javapoet
+  implementation deps.kotlinpoet
   implementation deps.kotlin.stdLibJdk8
 
   testImplementation deps.junit

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifeExtension.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ButterKnifeExtension.kt
@@ -1,0 +1,6 @@
+package butterknife.plugin
+
+open class ButterKnifeExtension {
+  /** If set to `true`, the generated R2 class will be in Kotlin. Otherwise it will be Java */
+  var generateKotlin: Boolean = false
+}

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/JavaR2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/JavaR2ClassBuilder.kt
@@ -36,7 +36,7 @@ internal class JavaR2ClassBuilder: R2ClassBuilder {
         .writeTo(outputDir)
   }
 
-  override fun addResourceField(type: ResourceType, fieldName: String, fieldValue: String) {
+  override fun addResourceConstant(type: ResourceType, fieldName: String, fieldValue: String) {
     val fieldSpecBuilder = FieldSpec.builder(Int::class.javaPrimitiveType, fieldName)
         .addModifiers(PUBLIC, STATIC, FINAL)
         .initializer(fieldValue)

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/JavaR2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/JavaR2ClassBuilder.kt
@@ -1,47 +1,42 @@
 package butterknife.plugin
 
+import butterknife.plugin.R2ClassBuilder.Companion.ResourceType
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
+import java.io.File
 import java.util.Locale
 import javax.lang.model.element.Modifier.FINAL
 import javax.lang.model.element.Modifier.PUBLIC
 import javax.lang.model.element.Modifier.STATIC
 
-
-private const val ANNOTATION_PACKAGE = "androidx.annotation"
-internal val SUPPORTED_TYPES = setOf("anim", "array", "attr", "bool", "color", "dimen",
-    "drawable", "id", "integer", "layout", "menu", "plurals", "string", "style", "styleable")
-
 /**
- * Generates a class that contains all supported field names in an R file as final values.
+ * Generates a Java class that contains all supported field names in an R file as final values.
  * Also enables adding support annotations to indicate the type of resource for every field.
  */
-class FinalRClassBuilder(
-  private val packageName: String,
-  private val className: String
-) {
+internal class JavaR2ClassBuilder: R2ClassBuilder {
 
   private var resourceTypes = mutableMapOf<String, TypeSpec.Builder>()
 
-  fun build(): JavaFile {
+  override fun write(
+      packageName: String,
+      className: String,
+      outputDir: File) {
     val result = TypeSpec.classBuilder(className)
         .addModifiers(PUBLIC, FINAL)
-    for (type in SUPPORTED_TYPES) {
-      resourceTypes.get(type)?.let {
+    for (type in ResourceType.values()) {
+      resourceTypes[type.renderString]?.let {
         result.addType(it.build())
       }
     }
-    return JavaFile.builder(packageName, result.build())
+    JavaFile.builder(packageName, result.build())
         .addFileComment("Generated code from Butter Knife gradle plugin. Do not modify!")
         .build()
+        .writeTo(outputDir)
   }
 
-  fun addResourceField(type: String, fieldName: String, fieldValue: String) {
-    if (type !in SUPPORTED_TYPES) {
-      return
-    }
+  override fun addResourceField(type: ResourceType, fieldName: String, fieldValue: String) {
     val fieldSpecBuilder = FieldSpec.builder(Int::class.javaPrimitiveType, fieldName)
         .addModifiers(PUBLIC, STATIC, FINAL)
         .initializer(fieldValue)
@@ -49,14 +44,14 @@ class FinalRClassBuilder(
     fieldSpecBuilder.addAnnotation(getSupportAnnotationClass(type))
 
     val resourceType =
-        resourceTypes.getOrPut(type) {
-          TypeSpec.classBuilder(type).addModifiers(PUBLIC, STATIC, FINAL)
+        resourceTypes.getOrPut(type.renderString) {
+          TypeSpec.classBuilder(type.renderString).addModifiers(PUBLIC, STATIC, FINAL)
         }
     resourceType.addField(fieldSpecBuilder.build())
   }
 
-  private fun getSupportAnnotationClass(type: String): ClassName {
-    return ClassName.get(ANNOTATION_PACKAGE, type.capitalize(Locale.US) + "Res")
+  private fun getSupportAnnotationClass(type: ResourceType): ClassName {
+    return ClassName.get(R2ClassBuilder.ANNOTATION_PACKAGE, type.renderString.capitalize(Locale.US) + "Res")
   }
 
   // TODO https://youtrack.jetbrains.com/issue/KT-28933

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/JavaR2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/JavaR2ClassBuilder.kt
@@ -53,7 +53,4 @@ internal class JavaR2ClassBuilder: R2ClassBuilder {
   private fun getSupportAnnotationClass(type: ResourceType): ClassName {
     return ClassName.get(R2ClassBuilder.ANNOTATION_PACKAGE, type.renderString.capitalize(Locale.US) + "Res")
   }
-
-  // TODO https://youtrack.jetbrains.com/issue/KT-28933
-  private fun String.capitalize(locale: Locale) = substring(0, 1).toUpperCase(locale) + substring(1)
 }

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/KotlinR2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/KotlinR2ClassBuilder.kt
@@ -1,0 +1,57 @@
+package butterknife.plugin
+
+import butterknife.plugin.R2ClassBuilder.Companion.ResourceType
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.KModifier.CONST
+import com.squareup.kotlinpoet.KModifier.PUBLIC
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import java.io.File
+import java.util.Locale
+
+/**
+ * Generates a Kotlin object that contains all supported field names in an R file as `const` values.
+ * Also enables adding support annotations to indicate the type of resource for every property.
+ */
+internal class KotlinR2ClassBuilder: R2ClassBuilder {
+
+  private var resourceTypes = mutableMapOf<String, TypeSpec.Builder>()
+
+  override fun write(
+      packageName: String,
+      className: String,
+      outputDir: File) {
+    val result = TypeSpec.objectBuilder(className)
+        .addModifiers(PUBLIC)
+    for (type in ResourceType.values()) {
+      resourceTypes[type.renderString]?.let {
+        result.addType(it.build())
+      }
+    }
+    FileSpec.builder(packageName, className)
+        .addComment("Generated code from Butter Knife gradle plugin. Do not modify!")
+        .addType(result.build())
+        .build()
+        .writeTo(outputDir)
+  }
+
+  override fun addResourceConstant(type: ResourceType, fieldName: String, fieldValue: String) {
+    val propertySpecBuilder = PropertySpec.builder(fieldName, INT)
+        .addModifiers(PUBLIC, CONST)
+        .initializer(fieldValue)
+
+    propertySpecBuilder.addAnnotation(getSupportAnnotationClass(type))
+
+    val resourceType =
+        resourceTypes.getOrPut(type.renderString) {
+          TypeSpec.objectBuilder(type.renderString).addModifiers(PUBLIC)
+        }
+    resourceType.addProperty(propertySpecBuilder.build())
+  }
+
+  private fun getSupportAnnotationClass(type: ResourceType): ClassName {
+    return ClassName(R2ClassBuilder.ANNOTATION_PACKAGE, type.renderString.capitalize(Locale.US) + "Res")
+  }
+}

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/KotlinR2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/KotlinR2ClassBuilder.kt
@@ -32,6 +32,7 @@ internal class KotlinR2ClassBuilder: R2ClassBuilder {
     }
     FileSpec.builder(packageName, className)
         .addComment("Generated code from Butter Knife gradle plugin. Do not modify!")
+        .indent("  ")
         .addType(result.build())
         .build()
         .writeTo(outputDir)

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2ClassBuilder.kt
@@ -1,0 +1,59 @@
+package butterknife.plugin
+
+import java.io.File
+
+/**
+ * High level interface for an "R2" class generator.
+ */
+internal interface R2ClassBuilder {
+  /**
+   * Adds a new resource field to render.
+   *
+   * @param type the [ResourceType].
+   * @param fieldName the resource field name.
+   * @param fieldValue the constant resource field value.
+   */
+  fun addResourceField(type: ResourceType, fieldName: String, fieldValue: String)
+
+  /**
+   * Writes the created class to the given output directory. Package structure will be created as
+   * needed.
+   *
+   * @property packageName the package name to write the RClass too
+   * @property className the simple class name to use for the RClass.
+   * @param outputDir the output directory.
+   */
+  fun write(
+      packageName: String,
+      className: String,
+      outputDir: File)
+
+  companion object {
+    /** The androidx annotations package. */
+    const val ANNOTATION_PACKAGE = "androidx.annotation"
+
+    /** Supported resource types. */
+    enum class ResourceType(val renderString: String) {
+      ANIM("anim"),
+      ARRAY("array"),
+      ATTR("attr"),
+      BOOL("bool"),
+      COLOR("color"),
+      DIMEN("dimen"),
+      DRAWABLE("drawable"),
+      ID("id"),
+      INTEGER("integer"),
+      LAYOUT("layout"),
+      MENU("menu"),
+      PLURALS("plurals"),
+      STRING("string"),
+      STYLE("style"),
+      STYLEABLE("styleable");
+
+      companion object {
+        /** Mapping of all the renderStrings to [ResourceType] for lookups. */
+        val RENDER_MAPPING = values().associate { it.renderString to it }
+      }
+    }
+  }
+}

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2ClassBuilder.kt
@@ -7,13 +7,13 @@ import java.io.File
  */
 internal interface R2ClassBuilder {
   /**
-   * Adds a new resource field to render.
+   * Adds a new resource constant to render.
    *
    * @param type the [ResourceType].
    * @param fieldName the resource field name.
    * @param fieldValue the constant resource field value.
    */
-  fun addResourceField(type: ResourceType, fieldName: String, fieldValue: String)
+  fun addResourceConstant(type: ResourceType, fieldName: String, fieldValue: String)
 
   /**
    * Writes the created class to the given output directory. Package structure will be created as

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2ClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2ClassBuilder.kt
@@ -1,6 +1,10 @@
 package butterknife.plugin
 
 import java.io.File
+import java.util.Locale
+
+// TODO https://youtrack.jetbrains.com/issue/KT-28933
+internal fun String.capitalize(locale: Locale) = substring(0, 1).toUpperCase(locale) + substring(1)
 
 /**
  * High level interface for an "R2" class generator.

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
@@ -10,21 +10,21 @@ import java.io.File
 
 open class R2Generator : DefaultTask() {
   @get:OutputDirectory
-  var outputDir: File? = null
+  lateinit var outputDir: File
 
   @get:InputFiles
-  var rFile: FileCollection? = null
+  lateinit var rFile: FileCollection
 
   @get:Input
-  var packageName: String? = null
+  lateinit var packageName: String
 
   @get:Input
-  var className: String? = null
+  lateinit var className: String
 
   @Suppress("unused") // Invoked by Gradle.
   @TaskAction
   fun generate() {
-    generateFile(rFile!!.singleFile, outputDir!!, packageName!!, className!!)
+    generateFile(rFile.singleFile, outputDir, packageName, className)
   }
 }
 

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
@@ -23,19 +23,18 @@ open class R2Generator : DefaultTask() {
 
   @Suppress("unused") // Invoked by Gradle.
   @TaskAction
-  fun brewJava() {
-    brewJava(rFile!!.singleFile, outputDir!!, packageName!!, className!!)
+  fun generate() {
+    generateFile(rFile!!.singleFile, outputDir!!, packageName!!, className!!)
   }
 }
 
-fun brewJava(
+internal fun generateFile(
   rFile: File,
   outputDir: File,
   packageName: String,
   className: String
 ) {
-  FinalRClassBuilder(packageName, className)
+  JavaR2ClassBuilder()
       .also { ResourceSymbolListReader(it).readSymbolTable(rFile) }
-      .build()
-      .writeTo(outputDir)
+      .write(packageName, className, outputDir)
 }

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
@@ -28,7 +28,7 @@ open class R2Generator : DefaultTask() {
   }
 }
 
-internal fun generateFile(
+fun generateFile(
   rFile: File,
   outputDir: File,
   packageName: String,

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
@@ -21,10 +21,13 @@ open class R2Generator : DefaultTask() {
   @get:Input
   lateinit var className: String
 
+  @get:Input
+  var generateKotlin: Boolean = false
+
   @Suppress("unused") // Invoked by Gradle.
   @TaskAction
   fun generate() {
-    generateFile(rFile.singleFile, outputDir, packageName, className)
+    generateFile(rFile.singleFile, outputDir, packageName, className, generateKotlin)
   }
 }
 
@@ -32,9 +35,11 @@ fun generateFile(
   rFile: File,
   outputDir: File,
   packageName: String,
-  className: String
+  className: String,
+  generateKotlin: Boolean
 ) {
-  JavaR2ClassBuilder()
+  val classBuilder = if (generateKotlin) KotlinR2ClassBuilder() else JavaR2ClassBuilder()
+  classBuilder
       .also { ResourceSymbolListReader(it).readSymbolTable(rFile) }
       .write(packageName, className, outputDir)
 }

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ResourceSymbolListReader.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ResourceSymbolListReader.kt
@@ -22,6 +22,6 @@ internal class ResourceSymbolListReader(private val builder: R2ClassBuilder) {
     val resourceType = RENDER_MAPPING[symbolType] ?: return
     val name = values[2]
     val value = values[3]
-    builder.addResourceField(resourceType, name, value)
+    builder.addResourceConstant(resourceType, name, value)
   }
 }

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ResourceSymbolListReader.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ResourceSymbolListReader.kt
@@ -1,8 +1,9 @@
 package butterknife.plugin
 
+import butterknife.plugin.R2ClassBuilder.Companion.ResourceType.Companion.RENDER_MAPPING
 import java.io.File
 
-class ResourceSymbolListReader(private val builder: FinalRClassBuilder) {
+internal class ResourceSymbolListReader(private val builder: R2ClassBuilder) {
 
   fun readSymbolTable(symbolTable: File) {
     symbolTable.forEachLine { processLine(it) }
@@ -18,11 +19,9 @@ class ResourceSymbolListReader(private val builder: FinalRClassBuilder) {
       return
     }
     val symbolType = values[1]
-    if (symbolType !in SUPPORTED_TYPES) {
-      return
-    }
+    val resourceType = RENDER_MAPPING[symbolType] ?: return
     val name = values[2]
     val value = values[3]
-    builder.addResourceField(symbolType, name, value)
+    builder.addResourceField(resourceType, name, value)
   }
 }

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/BuildFilesRule.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/BuildFilesRule.kt
@@ -5,8 +5,15 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.io.File
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FUNCTION
 
 class BuildFilesRule(private val root: File) : TestRule {
+
+    @Target(FUNCTION)
+    @Retention(RUNTIME)
+    annotation class KotlinTest
+
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
@@ -20,6 +27,14 @@ class BuildFilesRule(private val root: File) : TestRule {
                 } else {
                     val buildFileTemplate = File(root, "../../build.gradle").readText()
                     buildFile.writeText(buildFileTemplate)
+                    if (description.getAnnotation(KotlinTest::class.java) != null) {
+                        buildFile.appendText("""
+
+                          butterKnife {
+                            generateKotlin = true
+                          }
+                        """.trimIndent())
+                    }
                 }
 
                 val manifestFile = File(root, "src/main/AndroidManifest.xml")

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/JavaRClassBuilderTest.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/JavaRClassBuilderTest.kt
@@ -8,17 +8,17 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
-class FinalRClassBuilderTest {
+class JavaRClassBuilderTest {
   @Rule @JvmField val tempFolder = TemporaryFolder()
 
-  @Test fun brewJava() {
+  @Test fun generateFile() {
     val packageName = "com.butterknife.example"
     val rFile = tempFolder.newFile("R.txt").also {
       it.writeText(javaClass.getResource("/fixtures/R.txt").readText())
     }
 
     val outputDir = tempFolder.newFolder()
-    brewJava(rFile, outputDir, packageName, "R2")
+    generateFile(rFile, outputDir, packageName, "R2")
 
     val actual = outputDir.resolve("com/butterknife/example/R2.java").readText()
     val expected = javaClass.getResource("/fixtures/R2.java").readText()

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/JavaRClassBuilderTest.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/JavaRClassBuilderTest.kt
@@ -18,7 +18,7 @@ class JavaRClassBuilderTest {
     }
 
     val outputDir = tempFolder.newFolder()
-    generateFile(rFile, outputDir, packageName, "R2")
+    generateFile(rFile, outputDir, packageName, "R2", false)
 
     val actual = outputDir.resolve("com/butterknife/example/R2.java").readText()
     val expected = javaClass.getResource("/fixtures/R2.java").readText()

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/KotlinRClassBuilderTest.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/KotlinRClassBuilderTest.kt
@@ -1,0 +1,25 @@
+package butterknife.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class KotlinRClassBuilderTest {
+  @Rule @JvmField val tempFolder = TemporaryFolder()
+
+  @Test fun generateFile() {
+    val packageName = "com.butterknife.example"
+    val rFile = tempFolder.newFile("R.txt").also {
+      it.writeText(javaClass.getResource("/fixtures/R.txt").readText())
+    }
+
+    val outputDir = tempFolder.newFolder()
+    generateFile(rFile, outputDir, packageName, "R2", true)
+
+    val actual = outputDir.resolve("com/butterknife/example/R2.kt").readText()
+    val expected = javaClass.getResource("/fixtures/R2.kt").readText()
+
+    assertEquals(expected.trim(), actual.trim())
+  }
+}

--- a/butterknife-gradle-plugin/src/test/resources/fixtures/R2.kt
+++ b/butterknife-gradle-plugin/src/test/resources/fixtures/R2.kt
@@ -1,0 +1,99 @@
+// Generated code from Butter Knife gradle plugin. Do not modify!
+package com.butterknife.example
+
+import androidx.annotation.AnimRes
+import androidx.annotation.ArrayRes
+import androidx.annotation.AttrRes
+import androidx.annotation.BoolRes
+import androidx.annotation.ColorRes
+import androidx.annotation.DimenRes
+import androidx.annotation.DrawableRes
+import androidx.annotation.IdRes
+import androidx.annotation.IntegerRes
+import androidx.annotation.LayoutRes
+import androidx.annotation.MenuRes
+import androidx.annotation.PluralsRes
+import androidx.annotation.StringRes
+import androidx.annotation.StyleRes
+import androidx.annotation.StyleableRes
+import kotlin.Int
+
+object R2 {
+  object anim {
+    @AnimRes
+    const val res: Int = 0x7f040001
+  }
+
+  object array {
+    @ArrayRes
+    const val res: Int = 0x7f040002
+  }
+
+  object attr {
+    @AttrRes
+    const val res: Int = 0x7f040003
+  }
+
+  object bool {
+    @BoolRes
+    const val res: Int = 0x7f040004
+  }
+
+  object color {
+    @ColorRes
+    const val res: Int = 0x7f040005
+  }
+
+  object dimen {
+    @DimenRes
+    const val res: Int = 0x7f040006
+  }
+
+  object drawable {
+    @DrawableRes
+    const val res: Int = 0x7f040007
+  }
+
+  object id {
+    @IdRes
+    const val res: Int = 0x7f040008
+  }
+
+  object integer {
+    @IntegerRes
+    const val res: Int = 0x7f040009
+  }
+
+  object layout {
+    @LayoutRes
+    const val res: Int = 0x7f040010
+  }
+
+  object menu {
+    @MenuRes
+    const val res: Int = 0x7f040011
+  }
+
+  object plurals {
+    @PluralsRes
+    const val res: Int = 0x7f040012
+  }
+
+  object string {
+    @StringRes
+    const val res: Int = 0x7f040013
+  }
+
+  object style {
+    @StyleRes
+    const val res: Int = 0x7f040014
+  }
+
+  object styleable {
+    @StyleableRes
+    const val resArray_child: Int = 0
+
+    @StyleableRes
+    const val resArray_child2: Int = 1
+  }
+}


### PR DESCRIPTION
This is a PR with a proposal implementation for generating Kotlin `R2` files. This would be a potential win for Kotlin consumers on the build side by not imposing a mixed source set cost.

The structure of the Kotlin versions would be simple: every class is an `object`, every field is a `const`. This is technically a bit more heavyweight than the Java equivalent since there's a singleton class being generated for each, but one would assume that all these R2 classes are being stripped in release anyway since they're only used for compile-time.

Example:
```kotlin
object R2 {
  object anim {
    @AnimRes const val fooAnim: Int = 0x7f040001
  }
}
```

This would be gated on a configurable gradle extension:

```gradle
butterKnife {
  generateKotlin = true
}
```

Opportunistically cleaned up the structure of the plugin a bit along the way.