### PR TITLE
Fix #1431: Update AGP version and check before using deprecated API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
       'minSdk': 14,
       'compileSdk': 28,
 
-      'androidTools': '26.2.0',
+      'androidTools': '26.3.1',
       'kotlin': '1.2.71',
 
       'release': '8.8.1',
@@ -14,7 +14,7 @@ buildscript {
   ext.deps = [
       android: [
           'runtime': 'com.google.android:android:4.1.1.4',
-          'gradlePlugin': "com.android.tools.build:gradle:3.1.4",
+          'gradlePlugin': "com.android.tools.build:gradle:3.3.1",
       ],
       'androidx': [
           'core': "androidx.core:core:1.0.0",


### PR DESCRIPTION
fixes #1431

Tested manually by `gradlew install` and consuming from `mavenLocal()`
on [these 3 projects (AGP 3.1.4, 3.2.1, 3.3.1)](https://github.com/JakeWharton/butterknife/files/2897977/test.zip)

Note: after this change 3.1 and 3.2 consumers will have to exclude AGP:
```gradle
classpath 'com.android.tools.build:gradle:3.1.4'
classpath ('com.jakewharton:butterknife-gradle-plugin:10.1.1-SNAPSHOT') {
	exclude group: 'com.android.tools.build'
}
```
this is because `butterknife-gradle-plugin` does `implementation deps.android.gradlePlugin` instead of `compileOnly deps.android.gradlePlugin`