### PR TITLE
Fix BindDimen Float Example on Website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -51,7 +51,7 @@
   @BindString(R.string.title) String title;
   @BindDrawable(R.drawable.graphic) Drawable graphic;
   @BindColor(R.color.red) int red; // int or ColorStateList field
-  @BindDimen(R.dimen.spacer) Float spacer; // int (for pixel size) or float (for exact value) field
+  @BindDimen(R.dimen.spacer) float spacer; // int (for pixel size) or float (for exact value) field
   // ...
 }</pre>
 


### PR DESCRIPTION
Currently, the website shows this as an example of how to bind a `float` dimen:
```java
@BindDimen(R.dimen.spacer) Float spacer; // int (for pixel size) or float (for exact value) field
```
Using `Float` as the type for the `spacer` variable will cause the following error:
```
error: @BindDimen field type must be 'int' or 'float'.
```
The type for the `spacer` variable here should be the primitive `float` type like this:
```java
@BindDimen(R.dimen.spacer) float spacer; // int (for pixel size) or float (for exact value) field
```