### PR TITLE
Use copyOfRange helper

### DIFF
--- a/butterknife-runtime/src/main/java/butterknife/internal/Utils.java
+++ b/butterknife-runtime/src/main/java/butterknife/internal/Utils.java
@@ -12,7 +12,7 @@ import androidx.annotation.IdRes;
 import androidx.annotation.UiThread;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
-import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("WeakerAccess") // Used by generated code.
@@ -59,13 +59,9 @@ public final class Utils {
         views[end++] = view;
       }
     }
-    if (end == length) {
-      return views;
-    }
-    //noinspection unchecked
-    T[] newViews = (T[]) Array.newInstance(views.getClass().getComponentType(), end);
-    System.arraycopy(views, 0, newViews, 0, end);
-    return newViews;
+    return end == length
+        ? views
+        : Arrays.copyOfRange(views, 0, end);
   }
 
   @SafeVarargs

--- a/butterknife-runtime/src/test/java/butterknife/UtilsTest.java
+++ b/butterknife-runtime/src/test/java/butterknife/UtilsTest.java
@@ -17,9 +17,10 @@ public final class UtilsTest {
     assertThat(listFilteringNull("One", "Two", null)).containsExactly("One", "Two");
     assertThat(listFilteringNull("One", null, "Two")).containsExactly("One", "Two");
     assertThat(listFilteringNull(null, "One", "Two")).containsExactly("One", "Two");
+    assertThat(listFilteringNull("One", "Two", "Three")).containsExactly("One", "Two", "Three");
   }
 
-  @Test public void arrayOfFiltersNull() {
+  @Test public void arrayFilteringNullRemovesNulls() {
     assertThat(arrayFilteringNull(null, null, null)).isEmpty();
     assertThat(arrayFilteringNull("One", null, null)).asList().containsExactly("One");
     assertThat(arrayFilteringNull(null, "One", null)).asList().containsExactly("One");
@@ -27,6 +28,14 @@ public final class UtilsTest {
     assertThat(arrayFilteringNull("One", "Two", null)).asList().containsExactly("One", "Two");
     assertThat(arrayFilteringNull("One", null, "Two")).asList().containsExactly("One", "Two");
     assertThat(arrayFilteringNull(null, "One", "Two")).asList().containsExactly("One", "Two");
+  }
+
+  @Test public void arrayFilteringNullReturnsOriginalWhenNoNulls() {
+    String[] input = { "One", "Two", "Three" };
+    String[] actual = arrayFilteringNull(input);
+    assertThat(actual).isSameAs(input);
+    // Even though we got the same reference back check to ensure its contents weren't mutated.
+    assertThat(actual).asList().containsExactly("One", "Two", "Three");
   }
 
   @Test public void testCastParam() {


### PR DESCRIPTION
Instead of creating and copying a subset of the array manually. This also expands the tests to ensure the original instance is returned unmodifed when no nulls are present.