### PR TITLE
Fix #1498: kotlin lib missing resource ID for OnClick annotation 

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingSet.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingSet.java
@@ -1,8 +1,5 @@
 package butterknife.compiler;
 
-import butterknife.OnTouch;
-import butterknife.internal.ListenerClass;
-import butterknife.internal.ListenerMethod;
 import com.google.common.collect.ImmutableList;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
@@ -26,6 +23,10 @@ import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
+
+import butterknife.OnTouch;
+import butterknife.internal.ListenerClass;
+import butterknife.internal.ListenerMethod;
 
 import static butterknife.compiler.ButterKnifeProcessor.ACTIVITY_TYPE;
 import static butterknife.compiler.ButterKnifeProcessor.DIALOG_TYPE;
@@ -774,6 +775,15 @@ final class BindingSet {
         viewIdMap.put(id, viewId);
       }
       return viewId;
+    }
+
+    boolean viewBindingsIdCoedIsNumber(Id id){
+      ViewBinding.Builder viewId = viewIdMap.get(id);
+      if (viewId == null) {
+        return id.coedIsNumber();
+      }else {
+        return false;
+      }
     }
 
     BindingSet build() {

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ButterKnifeProcessor.java
@@ -1,33 +1,5 @@
 package butterknife.compiler;
 
-import butterknife.BindAnim;
-import butterknife.BindArray;
-import butterknife.BindBitmap;
-import butterknife.BindBool;
-import butterknife.BindColor;
-import butterknife.BindDimen;
-import butterknife.BindDrawable;
-import butterknife.BindFloat;
-import butterknife.BindFont;
-import butterknife.BindInt;
-import butterknife.BindString;
-import butterknife.BindView;
-import butterknife.BindViews;
-import butterknife.OnCheckedChanged;
-import butterknife.OnClick;
-import butterknife.OnEditorAction;
-import butterknife.OnFocusChange;
-import butterknife.OnItemClick;
-import butterknife.OnItemLongClick;
-import butterknife.OnItemSelected;
-import butterknife.OnLongClick;
-import butterknife.OnPageChange;
-import butterknife.OnTextChanged;
-import butterknife.OnTouch;
-import butterknife.Optional;
-import butterknife.compiler.FieldTypefaceBinding.TypefaceStyles;
-import butterknife.internal.ListenerClass;
-import butterknife.internal.ListenerMethod;
 import com.google.auto.common.SuperficialValidation;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
@@ -74,6 +46,35 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
+
+import butterknife.BindAnim;
+import butterknife.BindArray;
+import butterknife.BindBitmap;
+import butterknife.BindBool;
+import butterknife.BindColor;
+import butterknife.BindDimen;
+import butterknife.BindDrawable;
+import butterknife.BindFloat;
+import butterknife.BindFont;
+import butterknife.BindInt;
+import butterknife.BindString;
+import butterknife.BindView;
+import butterknife.BindViews;
+import butterknife.OnCheckedChanged;
+import butterknife.OnClick;
+import butterknife.OnEditorAction;
+import butterknife.OnFocusChange;
+import butterknife.OnItemClick;
+import butterknife.OnItemLongClick;
+import butterknife.OnItemSelected;
+import butterknife.OnLongClick;
+import butterknife.OnPageChange;
+import butterknife.OnTextChanged;
+import butterknife.OnTouch;
+import butterknife.Optional;
+import butterknife.compiler.FieldTypefaceBinding.TypefaceStyles;
+import butterknife.internal.ListenerClass;
+import butterknife.internal.ListenerMethod;
 
 import static butterknife.internal.Constants.NO_RES_ID;
 import static java.util.Objects.requireNonNull;
@@ -124,6 +125,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
   private boolean debuggable = true;
 
   private final RScanner rScanner = new RScanner();
+  private final FindRScanner findRScanner = new FindRScanner();
 
   @Override public synchronized void init(ProcessingEnvironment env) {
     super.init(env);
@@ -999,7 +1001,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     for (Element element : env.getElementsAnnotatedWith(annotationClass)) {
       if (!SuperficialValidation.validateElement(element)) continue;
       try {
-        parseListenerAnnotation(annotationClass, element, builderMap, erasedTargetNames);
+        parseListenerAnnotation(annotationClass, element, builderMap, erasedTargetNames,env);
       } catch (Exception e) {
         StringWriter stackTrace = new StringWriter();
         e.printStackTrace(new PrintWriter(stackTrace));
@@ -1011,7 +1013,7 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
   }
 
   private void parseListenerAnnotation(Class<? extends Annotation> annotationClass, Element element,
-      Map<TypeElement, BindingSet.Builder> builderMap, Set<TypeElement> erasedTargetNames)
+      Map<TypeElement, BindingSet.Builder> builderMap, Set<TypeElement> erasedTargetNames, RoundEnvironment env)
       throws Exception {
     // This should be guarded by the annotation's @Target but it's worth a check for safe casting.
     if (!(element instanceof ExecutableElement) || element.getKind() != METHOD) {
@@ -1194,7 +1196,26 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
     Map<Integer, Id> resourceIds = elementToIds(element, annotationClass, ids);
 
     for (Map.Entry<Integer, Id> entry : resourceIds.entrySet()) {
-      if (!builder.addMethod(entry.getValue(), listener, method, binding)) {
+      Id id = entry.getValue();
+      if (builder.viewBindingsIdCoedIsNumber(entry.getValue())){
+        String rPackageName = ((Symbol.MethodSymbol) element).owner.owner.toString() + ".R";
+        findRScanner.reset();
+        findRScanner.rId = entry.getValue().value;
+        for (Element element1 : env.getRootElements()) {
+          if (element1.toString().equals(rPackageName)) {
+            JCTree tree = (JCTree) trees.getTree(element1);
+            if (tree != null) { // tree can be null if the references are compiled types and not source
+              tree.accept(findRScanner);
+              if (findRScanner.resourceId != null) {
+                id = findRScanner.resourceId;
+                break;
+              }
+            }
+            break;
+          }
+        }
+      }
+      if (!builder.addMethod(id, listener, method, binding)) {
         error(element, "Multiple listener methods with return value specified for ID %d. (%s.%s)",
             entry.getKey(), enclosingElement.getQualifiedName(), element.getSimpleName());
         return;
@@ -1380,6 +1401,37 @@ public final class ButterKnifeProcessor extends AbstractProcessor {
 
     void reset() {
       resourceIds.clear();
+    }
+  }
+
+  private static class FindRScanner extends TreeScanner {
+
+    Id resourceId = null;
+    int rId = -1;
+
+    @Override
+    public void visitVarDef(JCTree.JCVariableDecl var1) {
+      try {
+        if (rId != -1) {
+          int rIdValue = (Integer) ((JCTree.JCLiteral) var1.init).value;
+
+          if (rIdValue == rId) {
+            Symbol symbol = var1.sym;
+            if (symbol.getEnclosingElement() != null) {
+              try {
+                resourceId = new Id(rIdValue, symbol);
+              } catch (Exception ignored) {
+              }
+            }
+          }
+        }
+      } catch (Exception ignored) {
+      }
+    }
+
+    void reset() {
+      resourceId = null;
+      rId = -1;
     }
   }
 }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/Id.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/Id.java
@@ -1,9 +1,10 @@
 package butterknife.compiler;
 
-import androidx.annotation.Nullable;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.sun.tools.javac.code.Symbol;
+import java.util.regex.Pattern;
+import androidx.annotation.Nullable;
 
 /**
  * Represents an ID of an Android resource.
@@ -47,5 +48,10 @@ final class Id {
 
   @Override public String toString() {
     throw new UnsupportedOperationException("Please use value or code explicitly");
+  }
+
+  public boolean coedIsNumber(){
+    Pattern pattern = Pattern.compile("[\\d]*");
+    return pattern.matcher(code.toString()).matches();
   }
 }

--- a/butterknife-compiler/src/main/java/butterknife/compiler/ViewBinding.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/ViewBinding.java
@@ -1,7 +1,5 @@
 package butterknife.compiler;
 
-import butterknife.internal.ListenerClass;
-import butterknife.internal.ListenerMethod;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -9,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import butterknife.internal.ListenerClass;
+import butterknife.internal.ListenerMethod;
 
 final class ViewBinding {
   private final Id id;


### PR DESCRIPTION
I am very happy to be involved in this project. If there is a need to change, I am willing to do my utmost.

I solved this problem [Missing resource ID for OnClick annotation #1498](https://github.com/JakeWharton/butterknife/issues/1498)  these days . Next, I will analyze the reasons and solutions.Please take a look ,thanks

Reason:
When using kotlin, for the same resource, if you do not use other annotations (eg: @Bindview) before the event annotation (eg: @Onclick), after generating view_binding.java, the Utils.findRequiredView() uses a raw integer not R reference.

When the merged resource is packaged, the static value of the R file has changed. So it leads "Missing resource ID". 

Analysis:
The annotation processing of kotlin generates a stub java file and processes the annotation according to the java file.But at this time ,Java file already using raw integer

My solution is to solve in the process() method, if it is the first time use a raw integer, go through the R.java, find the corresponding static value in R.java, and use R reference replace it.
If the second time is a raw integer, it will not be processed because the same resource will use the same Id(butterknife.compiler.Id.java).

thanks