### PR TITLE
Add support for incremental annotation processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 
       'androidTools': '26.2.0',
       'kotlin': '1.2.71',
+      'incap' : '0.2',
 
       'release': '8.8.1',
   ]
@@ -46,6 +47,10 @@ buildscript {
       ],
       'kotlin': [
           'stdLibJdk8': "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
+      ],
+      'incap': [
+          'runtime': "net.ltgt.gradle.incap:incap:${versions.incap}",
+          'processor': "net.ltgt.gradle.incap:incap-processor:${versions.incap}",
       ]
   ]
 

--- a/butterknife-compiler/build.gradle
+++ b/butterknife-compiler/build.gradle
@@ -12,6 +12,9 @@ dependencies {
   compileOnly deps.auto.service
   compileOnly files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 
+  api deps.incap.runtime
+  compileOnly deps.incap.processor
+
   testImplementation deps.junit
   testImplementation deps.truth
 }


### PR DESCRIPTION
This commit adds incremental annotation processing support
to Butterknife. More specifically, it makes Butterknife an
isolating annotation processor. More information about what
this means can be found at
https://docs.gradle.org/current/userguide/java_plugin.html#isolating_annotation_processors.

Closes #1230