### PR TITLE
Make R2Generator task cacheable

### DIFF
--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
@@ -2,6 +2,7 @@ package butterknife.plugin
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -10,6 +11,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
+@CacheableTask
 open class R2Generator : DefaultTask() {
   @get:OutputDirectory
   var outputDir: File? = null

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/R2Generator.kt
@@ -5,6 +5,8 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -13,6 +15,7 @@ open class R2Generator : DefaultTask() {
   var outputDir: File? = null
 
   @get:InputFiles
+  @get:PathSensitive(PathSensitivity.NONE)
   var rFile: FileCollection? = null
 
   @get:Input


### PR DESCRIPTION
This allows `R2Generator` tasks to use the Gradle build cache to share their outputs.