### PR TITLE
Use fake ID values for R2

### DIFF
--- a/butterknife-gradle-plugin/build.gradle
+++ b/butterknife-gradle-plugin/build.gradle
@@ -17,4 +17,13 @@ dependencies {
   testImplementation deps.compiletesting
 }
 
+test {
+  dependsOn(':butterknife:installLocally')
+  dependsOn(':butterknife-annotations:installLocally')
+  dependsOn(':butterknife-compiler:installLocally')
+  dependsOn(':butterknife-runtime:installLocally')
+
+  systemProperty('butterknife.version', version)
+}
+
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/FinalRClassBuilder.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/FinalRClassBuilder.kt
@@ -1,6 +1,7 @@
 package butterknife.plugin
 
 import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
@@ -38,13 +39,13 @@ class FinalRClassBuilder(
         .build()
   }
 
-  fun addResourceField(type: String, fieldName: String, fieldValue: String) {
+  fun addResourceField(type: String, fieldName: String, fieldInitializer: CodeBlock) {
     if (type !in SUPPORTED_TYPES) {
       return
     }
     val fieldSpecBuilder = FieldSpec.builder(Int::class.javaPrimitiveType, fieldName)
         .addModifiers(PUBLIC, STATIC, FINAL)
-        .initializer(fieldValue)
+        .initializer(fieldInitializer)
 
     fieldSpecBuilder.addAnnotation(getSupportAnnotationClass(type))
 

--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ResourceSymbolListReader.kt
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/ResourceSymbolListReader.kt
@@ -1,8 +1,10 @@
 package butterknife.plugin
 
+import com.squareup.javapoet.CodeBlock
 import java.io.File
 
-class ResourceSymbolListReader(private val builder: FinalRClassBuilder) {
+internal class ResourceSymbolListReader(private val builder: FinalRClassBuilder) {
+  private var idValue = 0
 
   fun readSymbolTable(symbolTable: File) {
     symbolTable.forEachLine { processLine(it) }
@@ -22,7 +24,7 @@ class ResourceSymbolListReader(private val builder: FinalRClassBuilder) {
       return
     }
     val name = values[2]
-    val value = values[3]
+    val value = CodeBlock.of("\$L", ++idValue)
     builder.addResourceField(symbolType, name, value)
   }
 }

--- a/butterknife-gradle-plugin/src/test/build.gradle
+++ b/butterknife-gradle-plugin/src/test/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 repositories {
     google()
+    maven {
+        url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
 }
 
 android {
@@ -49,12 +53,6 @@ android {
         }
     }
 
-    sourceSets {
-        main.java.srcDirs += '../../../../../butterknife/src/main/java'
-        main.java.srcDirs += '../../../../../butterknife-runtime/src/main/java'
-        main.java.srcDirs += '../../../../../butterknife-annotations/src/main/java'
-    }
-
     lintOptions {
         checkReleaseBuilds false
     }
@@ -63,4 +61,6 @@ android {
 
 dependencies {
     implementation "androidx.core:core:1.0.0"
+    implementation "com.jakewharton:butterknife:${getProperty("butterknife.version")}"
+    annotationProcessor "com.jakewharton:butterknife-compiler:${getProperty("butterknife.version")}"
 }

--- a/butterknife-gradle-plugin/src/test/java/butterknife/plugin/FixturesTest.kt
+++ b/butterknife-gradle-plugin/src/test/java/butterknife/plugin/FixturesTest.kt
@@ -19,10 +19,13 @@ class FixturesTest(val fixtureRoot: File, val name: String) {
         val androidHome = androidHome()
         File(fixtureRoot, "local.properties").writeText("sdk.dir=$androidHome\n")
 
+        val butterKnifeVersion = System.getProperty("butterknife.version")!!
+
         val runner = GradleRunner.create()
                 .withProjectDir(fixtureRoot)
                 .withPluginClasspath()
-                .withArguments("clean", "assembleDebug", "assembleRelease", "--stacktrace")
+                .withArguments("clean", "assembleDebug", "assembleRelease", "--stacktrace",
+                        "-Pbutterknife.version=$butterKnifeVersion")
 
         if (File(fixtureRoot, "ignored.txt").exists()) {
             println("Skipping ignored test $name.")

--- a/butterknife-gradle-plugin/src/test/resources/fixtures/R2.java
+++ b/butterknife-gradle-plugin/src/test/resources/fixtures/R2.java
@@ -20,79 +20,79 @@ import androidx.annotation.StyleableRes;
 public final class R2 {
   public static final class anim {
     @AnimRes
-    public static final int res = 0x7f040001;
+    public static final int res = 1;
   }
 
   public static final class array {
     @ArrayRes
-    public static final int res = 0x7f040002;
+    public static final int res = 2;
   }
 
   public static final class attr {
     @AttrRes
-    public static final int res = 0x7f040003;
+    public static final int res = 3;
   }
 
   public static final class bool {
     @BoolRes
-    public static final int res = 0x7f040004;
+    public static final int res = 4;
   }
 
   public static final class color {
     @ColorRes
-    public static final int res = 0x7f040005;
+    public static final int res = 5;
   }
 
   public static final class dimen {
     @DimenRes
-    public static final int res = 0x7f040006;
+    public static final int res = 6;
   }
 
   public static final class drawable {
     @DrawableRes
-    public static final int res = 0x7f040007;
+    public static final int res = 7;
   }
 
   public static final class id {
     @IdRes
-    public static final int res = 0x7f040008;
+    public static final int res = 8;
   }
 
   public static final class integer {
     @IntegerRes
-    public static final int res = 0x7f040009;
+    public static final int res = 9;
   }
 
   public static final class layout {
     @LayoutRes
-    public static final int res = 0x7f040010;
+    public static final int res = 10;
   }
 
   public static final class menu {
     @MenuRes
-    public static final int res = 0x7f040011;
+    public static final int res = 11;
   }
 
   public static final class plurals {
     @PluralsRes
-    public static final int res = 0x7f040012;
+    public static final int res = 12;
   }
 
   public static final class string {
     @StringRes
-    public static final int res = 0x7f040013;
+    public static final int res = 13;
   }
 
   public static final class style {
     @StyleRes
-    public static final int res = 0x7f040014;
+    public static final int res = 14;
   }
 
   public static final class styleable {
     @StyleableRes
-    public static final int resArray_child = 0;
+    public static final int resArray_child = 15;
 
     @StyleableRes
-    public static final int resArray_child2 = 1;
+    public static final int resArray_child2 = 16;
   }
 }

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -42,15 +42,45 @@ def getRepositoryPassword() {
   return hasProperty('SONATYPE_NEXUS_PASSWORD') ? SONATYPE_NEXUS_PASSWORD : ""
 }
 
+def configurePom(pom) {
+  pom.groupId = GROUP
+  pom.artifactId = POM_ARTIFACT_ID
+  pom.version = VERSION_NAME
+
+  pom.project {
+    name POM_NAME
+    packaging POM_PACKAGING
+    description POM_DESCRIPTION
+    url POM_URL
+
+    scm {
+      url POM_SCM_URL
+      connection POM_SCM_CONNECTION
+      developerConnection POM_SCM_DEV_CONNECTION
+    }
+
+    licenses {
+      license {
+        name POM_LICENCE_NAME
+        url POM_LICENCE_URL
+        distribution POM_LICENCE_DIST
+      }
+    }
+
+    developers {
+      developer {
+        id POM_DEVELOPER_ID
+        name POM_DEVELOPER_NAME
+      }
+    }
+  }
+}
+
 afterEvaluate { project ->
   uploadArchives {
     repositories {
       mavenDeployer {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
 
         repository(url: getReleaseRepositoryUrl()) {
           authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
@@ -59,33 +89,19 @@ afterEvaluate { project ->
           authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
         }
 
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
+        configurePom(pom)
+      }
+    }
+  }
 
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
+  tasks.create("installLocally", Upload) {
+    configuration = configurations.archives
 
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
-            }
-          }
+    repositories {
+      mavenDeployer {
+        repository(url: "file://${rootProject.buildDir}/localMaven")
 
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
-        }
+        configurePom(pom)
       }
     }
   }
@@ -101,37 +117,7 @@ afterEvaluate { project ->
       repositories.mavenInstaller {
         configuration = configurations.archives
 
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
-
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
-
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
-            }
-          }
-
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
-        }
+        configurePom(pom)
       }
     }
 
@@ -152,37 +138,7 @@ afterEvaluate { project ->
   } else {
     install {
       repositories.mavenInstaller {
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
-
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
-
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
-            }
-          }
-
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
-        }
+        configurePom(pom)
       }
     }
 


### PR DESCRIPTION
These values are meaningless. We only need them to be unique which is trivially achievable with a counter.

This change is required, however, because AGP 3.6 will stop generating ID values in library projects. All values are set to 0 which obviously will prevent Butter Knife from correctly performing the reverse mapping from R2 value back to name.

Closes #1549.