### PR TITLE
Maybe we can

### DIFF
--- a/butterknife-compiler/src/main/java/butterknife/compiler/BindingSet.java
+++ b/butterknife-compiler/src/main/java/butterknife/compiler/BindingSet.java
@@ -467,7 +467,7 @@ final class BindingSet implements BindingInformationProvider {
             .addModifiers(PUBLIC)
             .returns(bestGuess(method.returnType()));
         String[] parameterTypes = method.parameters();
-        for (int i = 0, count = parameterTypes.length; i < count; i++) {
+        for (int i = 0; i < parameterTypes.length; i++) {
           callbackMethod.addParameter(bestGuess(parameterTypes[i]), "p" + i);
         }
 


### PR DESCRIPTION
Because ’parameterTypes.length‘ It is a value in itself. If you write as before, it may reduce the clarity of the code！So I think it can be modified in this way！